### PR TITLE
fix: Gemini 关闭思考时省略 reasoning_effort

### DIFF
--- a/app/src/main/java/com/gameocr/app/translate/OpenAiRequestPolicy.kt
+++ b/app/src/main/java/com/gameocr/app/translate/OpenAiRequestPolicy.kt
@@ -53,6 +53,10 @@ internal object RemoteThinkingPolicy {
                 style = OpenAiThinkingWireStyle.ENABLE_THINKING,
                 enableThinking = enabled,
             )
+            host == "generativelanguage.googleapis.com" -> OpenAiThinkingControl(
+                style = OpenAiThinkingWireStyle.REASONING_EFFORT,
+                reasoningEffort = if (enabled) "high" else null,
+            )
             else -> OpenAiThinkingControl(
                 style = OpenAiThinkingWireStyle.REASONING_EFFORT,
                 reasoningEffort = if (enabled) "high" else "none",

--- a/app/src/test/java/com/gameocr/app/translate/OpenAiRequestPolicyTest.kt
+++ b/app/src/test/java/com/gameocr/app/translate/OpenAiRequestPolicyTest.kt
@@ -3,6 +3,7 @@ package com.gameocr.app.translate
 import com.gameocr.app.data.OpenAiRequestOptions
 import com.gameocr.app.data.RuntimeTranslationPromptContext
 import com.gameocr.app.data.TranslationContextMode
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
@@ -256,6 +257,20 @@ class OpenAiRequestPolicyTest {
                 OpenAiThinkingWireStyle.ENABLE_THINKING,
                 enableThinking = false,
             ),
+            Case(
+                "Gemini omits reasoning_effort when thinking is disabled",
+                "https://generativelanguage.googleapis.com/v1beta/openai/",
+                false,
+                OpenAiThinkingWireStyle.REASONING_EFFORT,
+                reasoningEffort = null,
+            ),
+            Case(
+                "Gemini enables high reasoning",
+                "https://generativelanguage.googleapis.com/v1beta/openai/",
+                true,
+                OpenAiThinkingWireStyle.REASONING_EFFORT,
+                reasoningEffort = "high",
+            ),
         ).forEach { case ->
             val actual = RemoteThinkingPolicy.openAi(case.baseUrl, case.enabled)
             assertEquals(case.name, case.style, actual.style)
@@ -263,6 +278,27 @@ class OpenAiRequestPolicyTest {
             assertEquals(case.name, case.thinkingType, actual.thinking?.type)
             assertEquals(case.name, case.enableThinking, actual.enableThinking)
         }
+    }
+
+    @Test
+    fun `null reasoning effort is omitted from ChatRequest JSON`() {
+        val json = Json {
+            ignoreUnknownKeys = true
+            encodeDefaults = true
+            explicitNulls = false
+            coerceInputValues = true
+        }
+        val payload = json.encodeToString(
+            ChatRequest(
+                model = "gemini-3-flash-lite",
+                messages = listOf(ChatMessage(role = "user", content = "ping")),
+                reasoningEffort = null,
+            ),
+        )
+
+        assertFalse(
+            Json.parseToJsonElement(payload).jsonObject.containsKey("reasoning_effort"),
+        )
     }
 
     @Test


### PR DESCRIPTION
<!--
  感谢提 PR！请先确认：
  ⚠️  base 分支选的是 dev，不是 main —— main 受保护，不接受外部 PR
  ✅  已开 issue 讨论过方向（链接放下面 "关联 issue" 一栏）
-->

## 类型

* [ ] feat：新功能
* [x] fix：bug 修复
* [ ] docs：文档
* [ ] refactor：重构
* [ ] perf：性能
* [ ] i18n：翻译 / 本地化
* [ ] chore：构建 / CI / 工具链

## 改动说明

修复 Gemini OpenAI-compatible 接口在关闭 Thinking mode 时返回 `HTTP 400 INVALID_ARGUMENT` 的问题。

v0.4.4 中，未特别识别的 OpenAI-compatible provider 在关闭 Thinking mode 时会发送：

```json
"reasoning_effort": "none"
```

Gemini 3.x 不接受该值，因此正式翻译请求会失败；开启 Thinking mode 后发送 `"high"` 则可以正常工作。

本 PR 针对 `generativelanguage.googleapis.com` 增加 provider-specific 处理：

* Thinking mode 开启：继续发送 `reasoning_effort = "high"`
* Thinking mode 关闭：不发送 `reasoning_effort`，交由 Gemini 使用默认行为

DeepSeek、DashScope 以及其它 generic OpenAI-compatible endpoint 的现有行为保持不变。

同时补充以下单元测试：

* Gemini + Thinking OFF → `reasoningEffort == null`
* Gemini + Thinking ON → `reasoningEffort == "high"`
* `reasoningEffort = null` 序列化后不包含 `reasoning_effort` 字段

## 关联 issue

暂无。

## 自测

* [x] `./gradlew assembleDebug` 通过
* [ ] 真机或模拟器跑过 `./gradlew installDebug`
* [x] 主路径（启动截屏 → OCR → 翻译 → 叠加显示）通过
* [ ] 浅色 + 深色都过一下（如改 UI）
* [ ] 中 + 英文 UI 都过一下（如改 strings 或 Compose 内文案）

补充测试情况：

* GitHub Actions CI 构建成功，`assembleDebug` 与 lint 均通过。
* 使用 CI 产出的 `app-debug.apk` 在 Android 真机安装并测试通过。
* Gemini OpenAI-compatible endpoint：

  * Thinking mode OFF：翻译正常，不再返回 `HTTP 400 INVALID_ARGUMENT`
  * Thinking mode ON：翻译正常
* 已验证完整主路径：截屏 → OCR → Gemini 翻译 → 叠加显示。
* 本 PR 未涉及 UI 或文案修改，因此浅色 / 深色主题与中英文 UI 测试不适用。

## 截图 / 录屏（UI 改动必填）

无 UI 改动，不适用。

## 其它

此修改仅针对 Gemini OpenAI-compatible endpoint，不改变 DeepSeek、DashScope 或其它 generic OpenAI-compatible provider 的 Thinking mode 行为。
