### PR TITLE
feat: add root (su) screenshot mode as Shizuku-free alternative

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -113,7 +113,7 @@
             </intent-filter>
         </activity>
 
-        <!-- 截屏前台服务：mediaProjection 用于默认截屏；specialUse 用于 Shizuku 路径 -->
+        <!-- 截屏前台服务：mediaProjection 用于默认截屏；specialUse 用于 Shizuku / root 路径 -->
         <!-- configChanges 必须包含 orientation+screenSize+screenLayout+smallestScreenSize：
              旋转屏幕时由 Service 自己接 onConfigurationChanged，按比例重算悬浮窗位置 +
              updateViewLayout。否则旋转后悬浮窗位置会废（竖屏 y=200 横屏可能落到状态栏后）。 -->
@@ -124,7 +124,7 @@
             android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize">
             <property
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
-                android:value="Shizuku-based on-demand screen capture for OCR translation" />
+                android:value="Shizuku/root-based on-demand screen capture for OCR translation" />
         </service>
 
         <service

--- a/app/src/main/java/com/gameocr/app/capture/RootCapabilities.kt
+++ b/app/src/main/java/com/gameocr/app/capture/RootCapabilities.kt
@@ -1,0 +1,49 @@
+package com.gameocr.app.capture
+
+import java.io.File
+import java.util.concurrent.TimeUnit
+import timber.log.Timber
+
+/**
+ * root 能力探测。
+ *
+ * 检测路径覆盖常见 su 位置（Magisk / system 内置 / vendor 等）。真正判定是否可用时执行
+ * `su -c id`，退出码 0 且 stdout 含 `uid=0` / `(root)` 才认为 root 就绪。
+ */
+internal object RootCapabilities {
+
+    private val SU_PATHS = listOf(
+        "/system/bin/su",
+        "/system/xbin/su",
+        "/sbin/su",
+        "/su/bin/su",
+        "/vendor/bin/su",
+        "/system/bin/.ext/.su",
+        "/data/adb/magisk",
+    )
+
+    /** 轻量检测：常见 su 路径是否至少存在一个。capture 前调用，不真正 exec。 */
+    fun hasSuBinary(): Boolean = SU_PATHS.any { File(it).exists() }
+
+    /**
+     * 真正验证 root 是否可用：执行 `su -c id`。
+     * 注意：首次执行 Magisk 会弹 root 授权窗，可能耗时；应放在 IO 线程调用。
+     */
+    fun isRootAvailable(): Boolean {
+        return try {
+            val process = Runtime.getRuntime().exec(arrayOf("su", "-c", "id"))
+            val terminated = process.waitFor(3, TimeUnit.SECONDS)
+            if (!terminated) {
+                Timber.w("[root-cap] su id timed out; destroying")
+                runCatching { process.destroy() }
+                return false
+            }
+            val stdout = process.inputStream.bufferedReader().use { it.readText() }
+            val exit = process.exitValue()
+            exit == 0 && (stdout.contains("uid=0") || stdout.contains("(root)"))
+        } catch (t: Throwable) {
+            Timber.w(t, "[root-cap] id check threw")
+            false
+        }
+    }
+}

--- a/app/src/main/java/com/gameocr/app/capture/RootScreenshotter.kt
+++ b/app/src/main/java/com/gameocr/app/capture/RootScreenshotter.kt
@@ -1,0 +1,116 @@
+package com.gameocr.app.capture
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * 基于 root (su) 的截屏实现：通过 `su -c screencap` 在 root 权限下执行 raw `screencap`，
+ * 不兼容时回退到 `screencap -p` PNG。复用 [ShizukuRawScreencapDecoder] 解码 raw 头。
+ *
+ * 优势：
+ * - 免 MediaProjection 每次系统授权窗（Android 14+ 强制弹），与 Shizuku 路径等价
+ * - 不需要安装 / 配对 Shizuku，只需设备已 root（Magisk / KernelSU 等）
+ *
+ * 代价：
+ * - 首次执行时 Magisk 等会弹一次 root 授权窗（此后记住）
+ * - 每次截屏走 su 进程，~150-400ms，帧率上限 ~5 FPS，仅适合"按需触发"
+ *
+ * 与 [ShizukuScreenshotter] 的区别仅在进程执行方式：Shizuku 用 shell uid，
+ * 本类用 root uid 直接跑 `screencap`。
+ */
+class RootScreenshotter : Screenshotter {
+
+    private val released = AtomicBoolean(false)
+
+    override val isReady: Boolean
+        get() = !released.get() && runCatching { RootCapabilities.hasSuBinary() }.getOrDefault(false)
+
+    override suspend fun capture(): Bitmap? = withContext(Dispatchers.IO) {
+        if (!isReady) {
+            Timber.w("[root-cap] skip: not ready (released=%s, su=%s)",
+                released.get(),
+                runCatching { RootCapabilities.hasSuBinary() }.getOrDefault(false))
+            return@withContext null
+        }
+        try {
+            // Raw screencap avoids vendor-specific PNG stream corruption. Keep PNG as a
+            // compatibility fallback for devices whose raw header or pixel format is unknown.
+            val rawBitmap = executeScreencap(arrayOf("screencap"), "raw")?.let { bytes ->
+                runCatching { ShizukuRawScreencapDecoder.decode(bytes) }
+                    .onFailure { Timber.w(it, "[root-cap] raw decode threw") }
+                    .getOrNull()
+            }
+            if (rawBitmap != null) {
+                Timber.d("[root-cap] raw ok %dx%d", rawBitmap.width, rawBitmap.height)
+                return@withContext rawBitmap
+            }
+
+            Timber.w("[root-cap] raw capture/decode failed; retrying PNG")
+            val pngBytes = executeScreencap(arrayOf("screencap", "-p"), "png")
+                ?: return@withContext null
+            val bitmap = BitmapFactory.decodeByteArray(pngBytes, 0, pngBytes.size)
+            if (bitmap == null) {
+                Timber.w(
+                    "[root-cap] decode PNG failed, bytes=%d, head=%s",
+                    pngBytes.size,
+                    pngBytes.take(8).joinToString { "%02x".format(it) }
+                )
+            } else {
+                Timber.d("[root-cap] png ok %dx%d", bitmap.width, bitmap.height)
+            }
+            bitmap
+        } catch (t: Throwable) {
+            Timber.w(t, "[root-cap] capture threw")
+            null
+        }
+    }
+
+    private fun executeScreencap(command: Array<String>, format: String): ByteArray? {
+        return try {
+            val cmdLine = command.joinToString(" ")
+            val process = Runtime.getRuntime().exec(arrayOf("su", "-c", cmdLine))
+            // 先等退出，再读流，避免 su 授权等待时 readText 阻塞。
+            val terminated = process.waitFor(8, TimeUnit.SECONDS)
+            if (!terminated) {
+                Timber.w("[root-cap] %s timed out; destroying", format)
+                runCatching { process.destroy() }
+                return null
+            }
+            val out = ByteArrayOutputStream(16 * 1024 * 1024)
+            process.inputStream.use { it.copyTo(out) }
+            val exitCode = process.exitValue()
+            val bytes = out.toByteArray()
+            if (exitCode != 0) {
+                val error = runCatching {
+                    process.errorStream.use { String(it.readBytes()).take(300) }
+                }.getOrElse { "<no stderr>" }
+                Timber.w(
+                    "[root-cap] %s exit=%d, stdoutBytes=%d, stderr=%s",
+                    format,
+                    exitCode,
+                    bytes.size,
+                    error
+                )
+                null
+            } else if (bytes.isEmpty()) {
+                Timber.w("[root-cap] %s exit=0 but empty payload", format)
+                null
+            } else {
+                bytes
+            }
+        } catch (t: Throwable) {
+            Timber.w(t, "[root-cap] execute %s threw", format)
+            null
+        }
+    }
+
+    override fun release() {
+        released.set(true)
+    }
+}

--- a/app/src/main/java/com/gameocr/app/service/CaptureService.kt
+++ b/app/src/main/java/com/gameocr/app/service/CaptureService.kt
@@ -47,6 +47,8 @@ import com.gameocr.app.capture.LoopIndicatorMode
 import com.gameocr.app.capture.LoopRuntimePolicy
 import com.gameocr.app.capture.MediaProjectionScreenshotter
 import com.gameocr.app.capture.OverlayCaptureRect
+import com.gameocr.app.capture.RootCapabilities
+import com.gameocr.app.capture.RootScreenshotter
 import com.gameocr.app.capture.Screenshotter
 import com.gameocr.app.capture.ShizukuScreenshotter
 import com.gameocr.app.capture.diagnoseCaptureGeometry
@@ -306,15 +308,21 @@ class CaptureService : Service() {
         // 用户重复点"启动"按钮、或者切换 Shizuku ↔ MediaProjection 路径都走这条。
         cleanupCapture()
 
-        // 先判断要走的截屏路径：用户启用 Shizuku 且就绪 → Shizuku；否则 → MediaProjection
-        val useShizuku = intent.getBooleanExtra(EXTRA_USE_SHIZUKU, false) &&
+        // 先判断要走的截屏路径，优先级 root > Shizuku > MediaProjection：
+        // - 用户显式请求 root 且设备已 root（su 可用）→ RootScreenshotter，免弹窗
+        // - 用户启用 Shizuku 且就绪 → ShizukuScreenshotter，免弹窗
+        // - 否则 → MediaProjection（每次启动弹系统授权窗）
+        val useRoot = intent.getBooleanExtra(EXTRA_USE_ROOT, false) &&
+            RootCapabilities.hasSuBinary()
+        val useShizuku = !useRoot &&
+            intent.getBooleanExtra(EXTRA_USE_SHIZUKU, false) &&
             shizukuCapabilities.availability(this) == ShizukuCapabilities.Availability.READY
 
         // 前台服务：Android 14+ 必须显式传非零 type，否则 InvalidForegroundServiceTypeException。
-        // MediaProjection 路径走 MEDIA_PROJECTION；Shizuku 路径走 SPECIAL_USE。
+        // MediaProjection 路径走 MEDIA_PROJECTION；Shizuku / root 路径走 SPECIAL_USE（免截屏授权）。
         val fgType = when {
             Build.VERSION.SDK_INT < Build.VERSION_CODES.Q -> 0
-            useShizuku -> android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
+            useShizuku || useRoot -> android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_SPECIAL_USE
             else -> android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION
         }
         // Android 14+ HyperOS/MIUI 上常见 race：MediaProjectionRequestActivity onActivityResult
@@ -325,31 +333,38 @@ class CaptureService : Service() {
             return
         }
 
-        if (useShizuku) {
-            screenshotter = ShizukuScreenshotter()
-            Timber.i("CaptureService started with Shizuku path")
-        } else {
-            val resultCode = intent.getIntExtra(EXTRA_RESULT_CODE, 0)
-            val data = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                intent.getParcelableExtra(EXTRA_RESULT_DATA, Intent::class.java)
-            } else {
-                @Suppress("DEPRECATION") intent.getParcelableExtra(EXTRA_RESULT_DATA)
+        when {
+            useRoot -> {
+                screenshotter = RootScreenshotter()
+                Timber.i("CaptureService started with root path")
             }
-            if (data == null) {
-                Timber.w("MediaProjection result data is null")
-                stopSelf()
-                return
+            useShizuku -> {
+                screenshotter = ShizukuScreenshotter()
+                Timber.i("CaptureService started with Shizuku path")
             }
-            val mpm = getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
-            projection = mpm.getMediaProjection(resultCode, data)
-            val mp = projection
-            if (mp == null) {
-                Timber.w("getMediaProjection returned null")
-                stopSelf()
-                return
+            else -> {
+                val resultCode = intent.getIntExtra(EXTRA_RESULT_CODE, 0)
+                val data = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    intent.getParcelableExtra(EXTRA_RESULT_DATA, Intent::class.java)
+                } else {
+                    @Suppress("DEPRECATION") intent.getParcelableExtra(EXTRA_RESULT_DATA)
+                }
+                if (data == null) {
+                    Timber.w("MediaProjection result data is null")
+                    stopSelf()
+                    return
+                }
+                val mpm = getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
+                projection = mpm.getMediaProjection(resultCode, data)
+                val mp = projection
+                if (mp == null) {
+                    Timber.w("getMediaProjection returned null")
+                    stopSelf()
+                    return
+                }
+                screenshotter = MediaProjectionScreenshotter(this, mp)
+                Timber.i("CaptureService started with MediaProjection path")
             }
-            screenshotter = MediaProjectionScreenshotter(this, mp)
-            Timber.i("CaptureService started with MediaProjection path")
         }
 
         VerticalDiagnosticLog.i(
@@ -442,22 +457,31 @@ class CaptureService : Service() {
         startOcrWarmupIfNeeded()
         startLocalLlmWarmupIfNeeded()
 
-        // Shizuku 路径 dry-run：即使 availability == READY，未通过 ADB / root 配对的 Shizuku 也会
-        // 让 newProcess(screencap) 失败（exit=1）。立刻跑一次截屏，失败则用悬浮错误条引导用户改
+        // Shizuku / root 路径 dry-run：Shizuku 即使 availability == READY，未通过 ADB / root
+        // 配对的 Shizuku 也会让 newProcess(screencap) 失败（exit=1）；root 路径也可能因 su 未
+        // 真正授权 / 设备没 root 而失败。立刻跑一次截屏，失败则用悬浮错误条引导用户改
         // 用 MediaProjection 并 stopSelf——比让他看到通用「截屏失败」反复试错好。
-        if (useShizuku) {
+        if (useShizuku || useRoot) {
             scope.launch {
                 val shotter = screenshotter ?: return@launch
                 val test = shotter.capture()
                 if (test == null) {
-                    Timber.w("Shizuku dry-run failed; stopping service")
+                    Timber.w("shizuku/root dry-run failed; stopping service")
                     logRepository.error(
                         LogRepository.Category.CAPTURE,
-                        getString(R.string.log_msg_shizuku_dry_run_failed)
+                        if (useRoot) {
+                            getString(R.string.log_msg_root_dry_run_failed)
+                        } else {
+                            getString(R.string.log_msg_shizuku_dry_run_failed)
+                        }
                     )
                     mainScope.launch {
                         overlay?.showErrorHint(
-                            getString(R.string.toast_shizuku_dry_run_failed),
+                            if (useRoot) {
+                                getString(R.string.toast_root_dry_run_failed)
+                            } else {
+                                getString(R.string.toast_shizuku_dry_run_failed)
+                            },
                             durationMs = 8000L
                         )
                     }
@@ -4387,6 +4411,7 @@ class CaptureService : Service() {
         const val EXTRA_RESULT_CODE = "extra_result_code"
         const val EXTRA_RESULT_DATA = "extra_result_data"
         const val EXTRA_USE_SHIZUKU = "extra_use_shizuku"
+        const val EXTRA_USE_ROOT = "extra_use_root"
         private const val CAPTURE_CHROME_SETTLE_MS = 80L
 
         fun stopIntent(context: Context): Intent =

--- a/app/src/main/java/com/gameocr/app/ui/MainScreen.kt
+++ b/app/src/main/java/com/gameocr/app/ui/MainScreen.kt
@@ -120,6 +120,7 @@ import com.gameocr.app.BuildConfig
 import com.gameocr.app.R
 import com.gameocr.app.capture.CaptureRegion
 import com.gameocr.app.capture.MediaProjectionRequestActivity
+import com.gameocr.app.capture.RootCapabilities
 import com.gameocr.app.capture.RegionPickerActivity
 import com.gameocr.app.data.Settings as AppSettings
 import com.gameocr.app.data.SettingsRepository
@@ -173,6 +174,7 @@ fun MainScreen(
     var canDrawOverlay by remember { mutableStateOf(Settings.canDrawOverlays(context)) }
     var region by remember { mutableStateOf<CaptureRegion?>(null) }
     var shizukuAvail by remember { mutableStateOf(ShizukuCapabilities.Availability.NOT_INSTALLED) }
+    var rootAvail by remember { mutableStateOf(false) }
     var batteryOk by remember {
         mutableStateOf(RomHelper.isIgnoringBatteryOptimizations(context))
     }
@@ -300,14 +302,17 @@ fun MainScreen(
         AutoUpdateCheckOverlay()
     }
 
-    // Shizuku 就绪时默认选 Shizuku（用户未手动切换过的前提下）。
+    // root / Shizuku 可用时默认选最优路径（用户未手动切换过的前提下）。
     // 进入页面时 shizukuAvail 还在初始 NOT_INSTALLED，等 ON_RESUME 探测完才真实；
     // 这里跟着变化走，确保用户进来直接看到最优选项。
-    LaunchedEffect(shizukuAvail) {
+    LaunchedEffect(shizukuAvail, rootAvail) {
         if (!userOverrodeMode) {
-            startMode = if (shizukuAvail == ShizukuCapabilities.Availability.READY ||
-                shizukuAvail == ShizukuCapabilities.Availability.INSTALLED_NOT_GRANTED
-            ) StartMode.SHIZUKU else StartMode.MEDIA_PROJECTION
+            startMode = when {
+                rootAvail -> StartMode.ROOT
+                shizukuAvail == ShizukuCapabilities.Availability.READY ||
+                    shizukuAvail == ShizukuCapabilities.Availability.INSTALLED_NOT_GRANTED -> StartMode.SHIZUKU
+                else -> StartMode.MEDIA_PROJECTION
+            }
         }
     }
 
@@ -327,6 +332,7 @@ fun MainScreen(
                     canDrawOverlay = Settings.canDrawOverlays(context)
                     region = viewModel.currentRegion()
                     shizukuAvail = viewModel.shizukuAvailability(context)
+                    rootAvail = viewModel.rootAvailable()
                     batteryOk = RomHelper.isIgnoringBatteryOptimizations(context)
                     if (!batteryOk) {
                         repeat(5) {
@@ -556,6 +562,7 @@ fun MainScreen(
                 canDrawOverlay = canDrawOverlay,
                 region = region,
                 shizukuAvail = shizukuAvail,
+                rootAvail = rootAvail,
                 batteryOk = batteryOk,
                 serviceRunning = serviceRunning,
                 presets = presets,
@@ -614,6 +621,7 @@ fun MainScreen(
                     serviceRunning,
                     startMode,
                     shizukuAvail,
+                    rootAvail,
                 ),
                 galleryMeasurementKey = listOf(
                     canDrawOverlay,
@@ -654,7 +662,11 @@ fun MainScreen(
                             Text("  ${stringResource(R.string.main_action_stop)}", modifier = Modifier.padding(start = 4.dp))
                         }
                     } else {
-                        val modeLabel = if (startMode == StartMode.SHIZUKU) "Shizuku" else "MediaProjection"
+                        val modeLabel = when (startMode) {
+                            StartMode.ROOT -> "Root"
+                            StartMode.SHIZUKU -> "Shizuku"
+                            StartMode.MEDIA_PROJECTION -> "MediaProjection"
+                        }
                         Button(
                             modifier = Modifier.fillMaxWidth().height(56.dp),
                             onClick = {
@@ -682,6 +694,24 @@ fun MainScreen(
                                             )
                                         }
                                     }
+                                    StartMode.ROOT -> scope.launch {
+                                        rootAvail = viewModel.rootAvailable()
+                                        if (rootAvail) {
+                                            val svc = Intent(context, CaptureService::class.java).apply {
+                                                action = CaptureService.ACTION_START
+                                                putExtra(CaptureService.EXTRA_USE_ROOT, true)
+                                            }
+                                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                                                ContextCompat.startForegroundService(context, svc)
+                                            } else {
+                                                context.startService(svc)
+                                            }
+                                        } else {
+                                            snackbarHostState.showSnackbar(
+                                                context.getString(R.string.main_snack_root_unavailable)
+                                            )
+                                        }
+                                    }
                                 }
                             }
                         ) {
@@ -693,7 +723,7 @@ fun MainScreen(
                         }
                     }
 
-                    // 启动方式 tabs：服务运行中禁止切换；Shizuku 不可用时该项禁用
+                    // 启动方式 tabs：服务运行中禁止切换；Shizuku / Root 不可用时对应项禁用
                     Text(
                         stringResource(R.string.main_label_start_mode),
                         style = MaterialTheme.typography.labelLarge,
@@ -707,7 +737,7 @@ fun MainScreen(
                                 userOverrodeMode = true
                             },
                             enabled = !serviceRunning,
-                            shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+                            shape = SegmentedButtonDefaults.itemShape(index = 0, count = 3),
                             label = { Text("MediaProjection") }
                         )
                         SegmentedButton(
@@ -717,12 +747,25 @@ fun MainScreen(
                                 userOverrodeMode = true
                             },
                             enabled = !serviceRunning && shizukuUsable,
-                            shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+                            shape = SegmentedButtonDefaults.itemShape(index = 1, count = 3),
                             label = { Text("Shizuku") }
+                        )
+                        SegmentedButton(
+                            selected = startMode == StartMode.ROOT,
+                            onClick = {
+                                startMode = StartMode.ROOT
+                                userOverrodeMode = true
+                            },
+                            enabled = !serviceRunning && rootAvail,
+                            shape = SegmentedButtonDefaults.itemShape(index = 2, count = 3),
+                            label = { Text("Root") }
                         )
                     }
                     val hintRes = when {
                         startMode == StartMode.MEDIA_PROJECTION -> R.string.main_hint_media_projection
+                        startMode == StartMode.ROOT ->
+                            if (rootAvail) R.string.main_hint_root_ready
+                            else R.string.main_hint_root_not_available
                         shizukuAvail == ShizukuCapabilities.Availability.READY -> R.string.main_hint_shizuku_ready
                         shizukuAvail == ShizukuCapabilities.Availability.INSTALLED_NOT_GRANTED -> R.string.main_hint_shizuku_not_granted
                         shizukuAvail == ShizukuCapabilities.Availability.INSTALLED_NOT_PAIRED -> R.string.main_hint_shizuku_not_paired
@@ -1722,6 +1765,7 @@ private fun StatusPresetCarousel(
     canDrawOverlay: Boolean,
     region: CaptureRegion?,
     shizukuAvail: ShizukuCapabilities.Availability,
+    rootAvail: Boolean,
     batteryOk: Boolean,
     serviceRunning: Boolean,
     presets: List<TranslationPreset>,
@@ -1813,6 +1857,7 @@ private fun StatusPresetCarousel(
                     canDrawOverlay = canDrawOverlay,
                     region = region,
                     shizukuAvail = shizukuAvail,
+                    rootAvail = rootAvail,
                     batteryOk = batteryOk,
                     serviceRunning = serviceRunning,
                     modifier = Modifier.fillMaxSize(),
@@ -1895,6 +1940,7 @@ private fun StatusCard(
     canDrawOverlay: Boolean,
     region: CaptureRegion?,
     shizukuAvail: ShizukuCapabilities.Availability,
+    rootAvail: Boolean,
     batteryOk: Boolean,
     serviceRunning: Boolean,
     modifier: Modifier = Modifier,
@@ -1941,6 +1987,14 @@ private fun StatusCard(
                         ShizukuCapabilities.Availability.NOT_RUNNING -> R.string.main_status_shizuku_not_running
                         ShizukuCapabilities.Availability.NOT_INSTALLED -> R.string.main_status_shizuku_not_installed
                     }
+                )
+            )
+            StatusRow(
+                stringResource(R.string.main_status_root),
+                ok = rootAvail,
+                detail = stringResource(
+                    if (rootAvail) R.string.main_status_root_ready
+                    else R.string.main_status_root_not_available
                 )
             )
             StatusRow(stringResource(R.string.main_status_battery_whitelist), batteryOk)
@@ -2489,7 +2543,7 @@ private fun AutoUpdateCheckOverlay() {
 
 private val MainScreenHorizontalPadding = 16.dp
 
-private enum class StartMode { MEDIA_PROJECTION, SHIZUKU }
+private enum class StartMode { MEDIA_PROJECTION, SHIZUKU, ROOT }
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
@@ -2533,6 +2587,10 @@ class MainViewModel @Inject constructor(
     fun shizukuAvailability(context: android.content.Context): ShizukuCapabilities.Availability =
         shizukuCapabilities.availability(context)
     suspend fun ensureShizukuReady(): Boolean = shizukuManager.ensureReady()
+    /** root 可用性（轻量探测 su 二进制，不真正执行授权）。 */
+    suspend fun rootAvailable(): Boolean = withContext(Dispatchers.IO) {
+        RootCapabilities.hasSuBinary()
+    }
     internal suspend fun presetModelIssues(
         presets: List<TranslationPreset>,
     ): Map<String, List<TranslationPresetModelIssue>> = withContext(Dispatchers.IO) {

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -50,6 +50,9 @@
     <string name="main_usage_text">悬浮圆球：单击 = 执行当前操作；长按 = 打开弧形菜单；拖动 = 移动位置</string>
     <string name="main_usage_overlay_permission_required">请点击上方按钮，先授予悬浮窗权限。</string>
     <string name="main_hint_media_projection">每次启动会弹一次系统授权窗</string>
+    <string name="main_hint_root_ready">Root 已就绪：无需授权弹窗</string>
+    <string name="main_hint_root_not_available">未检测到 Root。请先解锁 Bootloader 并安装 Magisk / KernelSU。</string>
+    <string name="main_snack_root_unavailable">Root 不可用。请确保设备已 root（Magisk / KernelSU）并授予 root 权限。</string>
     <string name="main_hint_shizuku_ready">Shizuku 就绪，免每次授权弹窗</string>
     <string name="main_hint_shizuku_not_granted">Shizuku 已安装但未授权，启动时会请求授权</string>
     <string name="main_hint_shizuku_not_running">请先在系统中启动 Shizuku 应用</string>
@@ -71,6 +74,9 @@
     <string name="main_status_shizuku_not_running">服务未运行</string>
     <string name="main_status_shizuku_not_installed">未安装</string>
     <string name="main_status_shizuku_not_paired">未配对（无 shell 特权）</string>
+    <string name="main_status_root">Root</string>
+    <string name="main_status_root_ready">就绪</string>
+    <string name="main_status_root_not_available">不可用</string>
     <string name="main_status_battery_whitelist">电池白名单</string>
     <string name="main_status_enabled">已开</string>
     <string name="main_status_disabled">未开</string>
@@ -955,6 +961,7 @@
     <string name="toast_loop_on_smart">自动翻译已开启（文字稳定 %1$d ms 后触发）</string>
     <string name="toast_capture_failed">截屏失败：未拿到画面，建议重新启动捕获</string>
     <string name="toast_shizuku_dry_run_failed">Shizuku 截屏不可用——大概率没通过 ADB 配对。请打开 Shizuku 应用，用 ADB / 无线调试启动，或在主屏切换到 MediaProjection 启动方式。</string>
+    <string name="toast_root_dry_run_failed">Root 截屏不可用——su 可能被拦截或未完全授权。请检查 Magisk / KernelSU 授权，或在主屏切换到 MediaProjection 启动方式。</string>
     <string name="toast_ocr_failed_format">OCR 失败 [%1$s]：%2$s</string>
     <string name="toast_ocr_unreliable_result">OCR 置信度过低，未识别到有效文字。请调整截取区域；若截屏空白、黑屏或模糊，请检查是否开启了屏幕共享防护。</string>
 
@@ -993,6 +1000,7 @@
     <string name="log_msg_manga_mask_debug_saved_format">漫画蒙版调试图（%1$s）已保存；气泡通过：%2$d/%3$d</string>
     <string name="log_msg_manga_mask_debug_diagnostics_format">漫画气泡判定：%1$s</string>
     <string name="log_msg_shizuku_dry_run_failed">Shizuku dry-run 失败——大概率未通过 ADB 配对。已停止截屏服务。</string>
+    <string name="log_msg_root_dry_run_failed">Root dry-run 失败——su 不可用或未授权。已停止截屏服务。</string>
     <string name="log_msg_ocr_failed_format">OCR 识别失败 [%1$s]</string>
     <string name="log_msg_ocr_results_format">识别到 %1$d 段 [%2$s]: %3$s</string>
     <string name="log_msg_ocr_no_result_format">本帧无识别结果 [%1$s]</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,6 +50,9 @@
     <string name="main_usage_text">Floating ball: tap to run the current action; long-press to open the arc menu; drag to move.</string>
     <string name="main_usage_overlay_permission_required">Tap the button above to grant the overlay permission first.</string>
     <string name="main_hint_media_projection">A system permission dialog appears on each start</string>
+    <string name="main_hint_root_ready">Root ready: no permission dialog</string>
+    <string name="main_hint_root_not_available">Root not available. Unlock the bootloader and install Magisk / KernelSU first.</string>
+    <string name="main_snack_root_unavailable">Root is not available. Make sure the device is rooted (Magisk / KernelSU) and grant root permission.</string>
     <string name="main_hint_shizuku_ready">Shizuku ready: no permission dialog</string>
     <string name="main_hint_shizuku_not_granted">Shizuku installed but not granted; will request on start</string>
     <string name="main_hint_shizuku_not_running">Please start the Shizuku app first</string>
@@ -71,6 +74,9 @@
     <string name="main_status_shizuku_not_running">Service not running</string>
     <string name="main_status_shizuku_not_installed">Not installed</string>
     <string name="main_status_shizuku_not_paired">Not paired (no shell privilege)</string>
+    <string name="main_status_root">Root</string>
+    <string name="main_status_root_ready">Ready</string>
+    <string name="main_status_root_not_available">Not available</string>
     <string name="main_status_battery_whitelist">Battery whitelist</string>
     <string name="main_status_enabled">Enabled</string>
     <string name="main_status_disabled">Disabled</string>
@@ -956,6 +962,7 @@
     <string name="toast_loop_on_smart">Auto translate on (wait for text to remain stable for %1$d ms)</string>
     <string name="toast_capture_failed">Capture failed: no frame. Try restarting capture.</string>
     <string name="toast_shizuku_dry_run_failed">Shizuku capture isn\'t working — likely not paired via ADB. Open the Shizuku app and start it with ADB / wireless debug, or switch to MediaProjection on the main screen.</string>
+    <string name="toast_root_dry_run_failed">Root capture isn\'t working — su may be blocked or not fully granted. Check Magisk / KernelSU authorization, or switch to MediaProjection on the main screen.</string>
     <string name="toast_ocr_failed_format">OCR failed [%1$s]: %2$s</string>
     <string name="toast_ocr_unreliable_result">OCR confidence is too low to detect valid text. Adjust the capture region. If the captured image is blank, black, or blurred, check whether screen-sharing protection is enabled.</string>
 
@@ -994,6 +1001,7 @@
     <string name="log_msg_manga_mask_debug_saved_format">Manga mask diagnostic saved (%1$s); accepted bubbles: %2$d/%3$d</string>
     <string name="log_msg_manga_mask_debug_diagnostics_format">Manga bubble decisions: %1$s</string>
     <string name="log_msg_shizuku_dry_run_failed">Shizuku dry-run failed at service start — likely not paired via ADB. Stopped capture service.</string>
+    <string name="log_msg_root_dry_run_failed">Root dry-run failed at service start — su unavailable or not granted. Stopped capture service.</string>
     <string name="log_msg_ocr_failed_format">OCR failed [%1$s]</string>
     <string name="log_msg_ocr_results_format">Recognized %1$d block(s) [%2$s]: %3$s</string>
     <string name="log_msg_ocr_no_result_format">No text in this frame [%1$s]</string>


### PR DESCRIPTION
Implement a third capture path using root (su) to run screencap, avoiding both MediaProjection per-launch permission prompts and the Shizuku dependency.

- RootScreenshotter: runs su -c screencap (raw, fallback to PNG), reuses ShizukuRawScreencapDecoder
- RootCapabilities: su binary detection and root availability check
- CaptureService: prioritizes root > Shizuku > MediaProjection, dry-run guard
- MainScreen: ROOT start-mode tab, availability probe, status row
- Manifest/strings: specialUse subtype + new strings

Assisted-by: opencode

<!--
  感谢提 PR！请先确认：
  ⚠️  base 分支选的是 dev，不是 main —— main 受保护，不接受外部 PR
  ✅  已开 issue 讨论过方向（链接放下面 "关联 issue" 一栏）
-->

## 类型

<!-- 勾选最贴合的，其它删掉 -->

- [ ] feat：新功能
- [ ] fix：bug 修复
- [ ] docs：文档
- [ ] refactor：重构
- [ ] perf：性能
- [ ] i18n：翻译 / 本地化
- [ ] chore：构建 / CI / 工具链

## 改动说明

<!-- 一两句话说清做了什么、为什么 -->

## 关联 issue

<!-- Closes #123 / Refs #456 -->

## 自测

- [ ] `./gradlew assembleDebug` 通过
- [ ] 真机或模拟器跑过 `./gradlew installDebug`
- [ ] 主路径（启动截屏 → OCR → 翻译 → 叠加显示）通过
- [ ] 浅色 + 深色都过一下（如改 UI）
- [ ] 中 + 英文 UI 都过一下（如改 strings 或 Compose 内文案）

## 截图 / 录屏（UI 改动必填）

<!-- 拖动文件到此处上传即可 -->

## 其它

<!-- breaking change / 需要文档同步更新 / 等等 -->
