### PR TITLE
feat: 新增快捷设置磁贴一键启停截屏服务

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -136,6 +136,25 @@ android {
     }
 }
 
+// 🔴 单测任务的源码输入声明 —— 所有「读文件当文本断言」的契约测试的前提。这些文件不在单测
+// classpath 上，缺了它变化就不在依赖图上，任务直接报 UP-TO-DATE 复用旧结果（实测：去掉后改
+// AndroidManifest.xml 照旧 BUILD SUCCESSFUL）。范围要跟着**测试实际读到的文件**走，而不是跟着
+// 「代码」走 —— 覆盖一半比不覆盖更危险。src/main 内被读的还有 assets/*.txt 与 drawable 图片；
+// src/main 之外还有 NOTICE、版本目录、llama-android 的 cpp 源码与构建脚本（兄弟模块不享受
+// 「改本工程构建脚本即失效」那条隐式跟踪）。新增契约测试若读了别处文件必须同步加到这里 ——
+// src/main 含 19M 模型，全量参与指纹是刻意的代价，别为提速砍范围。
+tasks.withType<Test>().configureEach {
+    inputs.files(
+        fileTree("src/main"),
+        rootProject.file("NOTICE"),
+        rootProject.file("gradle/libs.versions.toml"),
+        rootProject.fileTree("llama-android/src/main/cpp"),
+        rootProject.file("llama-android/build.gradle.kts"),
+    )
+        .withPropertyName("sourceTextContractInputs")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+}
+
 dependencies {
     // AndroidX core
     implementation(libs.androidx.core.ktx)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -129,6 +129,28 @@
                 android:value="Shizuku-based on-demand screen capture for OCR translation" />
         </service>
 
+        <!-- 快捷设置磁贴：一键启动/停止截屏服务（issue #23）。
+             android:exported 必须为 true —— 绑定磁贴服务的是系统 SystemUI，不是本应用。
+             BIND_QUICK_SETTINGS_TILE 是系统侧的签名级权限，磁贴服务必须声明它才能被绑定。
+             META_DATA_ACTIVE_TILE=true 也**必须**声明：否则 TileService.requestListeningState()
+             对这个磁贴是静默无效的（不报错、不生效），服务自行停止后磁贴会一直停在「运行中」。 -->
+        <service
+            android:name=".tile.CaptureTileService"
+            android:exported="true"
+            android:icon="@drawable/ic_tile_capture"
+            android:label="@string/tile_capture_label"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:value="true" />
+            <meta-data
+                android:name="android.service.quicksettings.TOGGLEABLE_TILE"
+                android:value="true" />
+        </service>
+
         <service
             android:name="androidx.work.impl.foreground.SystemForegroundService"
             android:foregroundServiceType="dataSync"

--- a/app/src/main/java/com/gameocr/app/service/CaptureService.kt
+++ b/app/src/main/java/com/gameocr/app/service/CaptureService.kt
@@ -45,6 +45,7 @@ import com.gameocr.app.capture.LoopTextRoiPolicy
 import com.gameocr.app.capture.LoopActiveResultDecision
 import com.gameocr.app.capture.LoopIndicatorMode
 import com.gameocr.app.capture.LoopRuntimePolicy
+import com.gameocr.app.capture.MediaProjectionRequestActivity
 import com.gameocr.app.capture.MediaProjectionScreenshotter
 import com.gameocr.app.capture.OverlayCaptureRect
 import com.gameocr.app.capture.Screenshotter
@@ -54,6 +55,7 @@ import com.gameocr.app.capture.floatingWindowCaptureAction
 import com.gameocr.app.capture.mapOverlayBoundsToCapture
 import com.gameocr.app.capture.shouldHideFloatingButtonForCapture
 import com.gameocr.app.shizuku.ShizukuCapabilities
+import com.gameocr.app.tile.requestCaptureTileRefresh
 import com.gameocr.app.data.LogRepository
 import com.gameocr.app.data.LoopTriggerMode
 import com.gameocr.app.data.LoopTextRegionMode
@@ -306,7 +308,14 @@ class CaptureService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
             ACTION_START -> handleStart(intent)
-            ACTION_STOP -> stopSelf()
+            ACTION_STOP -> {
+                // 先翻转再销毁：销毁回调不保证执行，而磁贴点击后没有第二次刷新机会。
+                CaptureServiceState.setRunning(false)
+                // 磁贴在监听中时该请求无效（点击后不收起面板，磁贴仍在监听），
+                // 但主屏「停止」时磁贴不在监听，且 active 模式不会因打开面板而重绑，只能靠这次通知。
+                requestCaptureTileRefresh(this)
+                stopSelf()
+            }
             ACTION_TRIGGER_ONCE -> triggerOnce()
             ACTION_PICK_REGION -> showRegionPickerOverlay()
             ACTION_RUN_FLOATING_TOUR -> {
@@ -328,7 +337,8 @@ class CaptureService : Service() {
         // 用户重复点"启动"按钮、或者切换 Shizuku ↔ MediaProjection 路径都走这条。
         cleanupCapture()
 
-        // 先判断要走的截屏路径：用户启用 Shizuku 且就绪 → Shizuku；否则 → MediaProjection
+        // 先判断要走的截屏路径：调用方要求 Shizuku 且此刻仍就绪 → Shizuku；否则才考虑 MediaProjection ——
+        // 后者要求 intent 带授权 token（只有 MediaProjectionRequestActivity 会带），直连路径没带就只 stopSelf。
         val useShizuku = intent.getBooleanExtra(EXTRA_USE_SHIZUKU, false) &&
             shizukuCapabilities.availability(this) == ShizukuCapabilities.Availability.READY
 
@@ -358,7 +368,9 @@ class CaptureService : Service() {
                 @Suppress("DEPRECATION") intent.getParcelableExtra(EXTRA_RESULT_DATA)
             }
             if (data == null) {
+                // 直连路径唯一的失败模式：磁贴判定 Shizuku 就绪，服务侧复核时已经不成立。
                 Timber.w("MediaProjection result data is null")
+                handOffToProjectionGateway(intent)
                 stopSelf()
                 return
             }
@@ -464,6 +476,8 @@ class CaptureService : Service() {
         }
 
         CaptureServiceState.setRunning(true)
+        // 磁贴可能正开着 QS 面板显示「未运行」，状态变了要主动请系统重新回调一次。
+        requestCaptureTileRefresh(this)
         startOcrWarmupIfNeeded()
         startLocalLlmWarmupIfNeeded()
 
@@ -613,6 +627,8 @@ class CaptureService : Service() {
                     handleStart(originalIntent)
                 } catch (e2: SecurityException) {
                     Timber.e(e2, "startForeground retry also failed")
+                    // 前台化都没成功，交接授权窗是唯一还能把用户接回正轨的动作。
+                    handOffToProjectionGateway(originalIntent)
                     logRepository.error(
                         LogRepository.Category.CAPTURE,
                         "startForeground SecurityException after retry: ${e2.message}",
@@ -623,6 +639,23 @@ class CaptureService : Service() {
             }, 200L)
             false
         }
+    }
+
+    /**
+     * 启动已经失败、服务即将 `stopSelf()` 时把用户交给授权窗 —— 是否该做由 [decideCaptureStartRecovery]
+     * 判定。服务此时可能还没前台化，所以这一步依赖 SAW 的 BAL 豁免（直连路由必然持有悬浮窗权限）。
+     */
+    private fun handOffToProjectionGateway(intent: Intent) {
+        val recovery = decideCaptureStartRecovery(
+            CaptureStartRecoveryInput(
+                tokenPresent = intent.hasExtra(EXTRA_RESULT_DATA),
+                shizukuRequested = intent.getBooleanExtra(EXTRA_USE_SHIZUKU, false),
+            )
+        )
+        if (recovery != CaptureStartRecovery.OPEN_PROJECTION_GATEWAY) return
+        Timber.i("capture start failed on the Shizuku direct path; handing off to the gateway")
+        runCatching { startActivity(MediaProjectionRequestActivity.newIntent(this)) }
+            .onFailure { Timber.w(it, "projection gateway handoff rejected") }
     }
 
     private fun triggerOnce() {
@@ -4720,6 +4753,11 @@ class CaptureService : Service() {
         scope.cancel()
         mainScope.cancel()
         CaptureServiceState.setRunning(false)
+        // 服务自己失败退出（Shizuku dry-run 判失败后 stopSelf）时，磁贴必须立刻从「运行中」翻回
+        // 「未运行」，否则下次点击会被路由成 STOP —— 用户以为在启动，实际什么都没发生。
+        requestCaptureTileRefresh(this)
+        // 面板还开着时上面那次刷新会被系统吞掉；磁贴靠这个计数自己发现「这次启动已经没结果了」。
+        CaptureServiceState.signalStoppedWithoutRunning()
         Timber.i("CaptureService destroyed")
         super.onDestroy()
     }

--- a/app/src/main/java/com/gameocr/app/service/CaptureServiceState.kt
+++ b/app/src/main/java/com/gameocr/app/service/CaptureServiceState.kt
@@ -3,16 +3,30 @@ package com.gameocr.app.service
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 
 /**
  * 全进程内 CaptureService 运行状态。UI（MainScreen）观察这个 StateFlow 显示运行中/未运行，
- * 并据此 enable/disable 启动/停止按钮，避免用户重复点。
+ * 并据此 enable/disable 启动/停止按钮，避免用户重复点。磁贴也读它 —— 同进程，免费。
  */
 object CaptureServiceState {
     private val _running = MutableStateFlow(false)
     val running: StateFlow<Boolean> = _running.asStateFlow()
 
+    /**
+     * 服务实例在「未处于运行状态」时结束的累计次数。只有两种情形会 +1：启动尝试失败、以及一次
+     * 正常停止 —— 对观察者来说两者的答案都是「没起来」。单调递增且从不重置：磁贴比较自己点击
+     * 前后的取值来判断这次启动有没有结果，不会被上一轮遗留的取值骗到。
+     */
+    private val _stoppedWithoutRunning = MutableStateFlow(0)
+    val stoppedWithoutRunning: StateFlow<Int> = _stoppedWithoutRunning.asStateFlow()
+
     internal fun setRunning(v: Boolean) {
         _running.value = v
+    }
+
+    internal fun signalStoppedWithoutRunning() {
+        // 用 update 而非 `value += 1`：读-改-写丢计数，而这里的承诺是「从不丢失」。
+        _stoppedWithoutRunning.update { it + 1 }
     }
 }

--- a/app/src/main/java/com/gameocr/app/service/CaptureStartRecoveryPolicy.kt
+++ b/app/src/main/java/com/gameocr/app/service/CaptureStartRecoveryPolicy.kt
@@ -1,0 +1,29 @@
+package com.gameocr.app.service
+
+/** 启动失败后还能做什么。 */
+internal enum class CaptureStartRecovery {
+    NONE,
+    OPEN_PROJECTION_GATEWAY,
+}
+
+/**
+ * @param tokenPresent 本 intent 是否已带 MediaProjection 授权 token。
+ * @param shizukuRequested 调用方是否要求走 Shizuku（只有磁贴直连会带 `EXTRA_USE_SHIZUKU`）。
+ */
+internal data class CaptureStartRecoveryInput(
+    val tokenPresent: Boolean,
+    val shizukuRequested: Boolean,
+)
+
+/**
+ * 启动已失败、服务即将 `stopSelf()` 时，是否要把用户交给
+ * [com.gameocr.app.capture.MediaProjectionRequestActivity]：直连路径不带授权 token，服务侧复核不成立后
+ * 就只剩「点了没反应」（Toast 被 ROM 丢、服务没起来画不出悬浮错误条、面板开着时磁贴刷新又被系统吞），
+ * 而缺的那个 token 只能由系统授权窗产出；反过来，带 token 的启动一定是授权窗自己发起的，再拉起它会让
+ * 用户在「弹窗 → 失败 → 弹窗」之间打转。
+ */
+internal fun decideCaptureStartRecovery(input: CaptureStartRecoveryInput): CaptureStartRecovery = when {
+    input.tokenPresent -> CaptureStartRecovery.NONE
+    input.shizukuRequested -> CaptureStartRecovery.OPEN_PROJECTION_GATEWAY
+    else -> CaptureStartRecovery.NONE
+}

--- a/app/src/main/java/com/gameocr/app/tile/CaptureStartRoutePolicy.kt
+++ b/app/src/main/java/com/gameocr/app/tile/CaptureStartRoutePolicy.kt
@@ -1,0 +1,60 @@
+package com.gameocr.app.tile
+
+/** 磁贴一次点击的去向。名字里的 "Start" 是历史遗留（表里也含停止与补权限）。[TRAMPOLINE] 指经 MediaProjection 授权窗中转。 */
+internal enum class CaptureStartRoute {
+    STOP,
+    DIRECT_FGS,
+    TRAMPOLINE,
+    BLOCKED_NEED_UNLOCK,
+    NEEDS_OVERLAY_PERMISSION,
+    UNAVAILABLE,
+}
+
+/**
+ * @param canDrawOverlay 必须用 `Settings.canDrawOverlays()` 回读，不能相信自己刚做的权限写入。
+ * @param preferShizuku 由调用方按「Shizuku 是否 READY」推导：主屏的 StartMode 是本地 Compose 状态、
+ *   不持久化，磁贴读不到用户的显式选择；且比主屏窄一档 —— 主屏还能用 `ensureShizukuReady()` 引导授权，
+ *   磁贴没有这条路，未授权就直连只会得到一个跑不动 `screencap` 的 Shizuku。
+ */
+internal data class CaptureStartRouteInput(
+    val setupCompleted: Boolean,
+    val canDrawOverlay: Boolean,
+    val serviceRunning: Boolean,
+    val isLocked: Boolean,
+    val preferShizuku: Boolean,
+)
+
+/**
+ * @param useShizuku 这是「请求」而非保证：服务会用更新的一次探测覆盖它。覆盖失败时服务直接
+ *   `stopSelf()`（直连路径不带 MediaProjection token，没有可回落的东西），不会自行降级 ——
+ *   回落授权窗只发生在经 `MediaProjectionRequestActivity` 的中转路径上。
+ */
+internal data class CaptureStartDecision(
+    val route: CaptureStartRoute,
+    val useShizuku: Boolean,
+)
+
+/** 纯策略：把点击路由到具体动作。判定顺序即优先级，前一条命中即返回。 */
+internal fun decideCaptureStartRoute(input: CaptureStartRouteInput): CaptureStartDecision {
+    if (!input.setupCompleted) {
+        return CaptureStartDecision(CaptureStartRoute.UNAVAILABLE, useShizuku = false)
+    }
+    // 停止压过悬浮窗权限与后续启动条件（权限被事后回收时用户仍要能把服务关掉），但压不过 setup 闸门。
+    if (input.serviceRunning) {
+        return CaptureStartDecision(CaptureStartRoute.STOP, useShizuku = false)
+    }
+    // 排在 preferShizuku 之前：Shizuku 能让服务起来，但画不出悬浮球，用户会以为磁贴坏了。
+    if (!input.canDrawOverlay) {
+        return CaptureStartDecision(CaptureStartRoute.NEEDS_OVERLAY_PERMISSION, useShizuku = false)
+    }
+    // Shizuku 路径不需要可见 Activity 承载授权框，故能排在锁屏闸门之前（锁屏直起尚未真机验证）。（与「服务不画 UI」无关 —— 它画悬浮球。）
+    if (input.preferShizuku) {
+        return CaptureStartDecision(CaptureStartRoute.DIRECT_FGS, useShizuku = true)
+    }
+    // MediaProjection 的授权窗必须有可见 Activity 承载，且锁屏下无法显示。
+    return if (input.isLocked) {
+        CaptureStartDecision(CaptureStartRoute.BLOCKED_NEED_UNLOCK, useShizuku = false)
+    } else {
+        CaptureStartDecision(CaptureStartRoute.TRAMPOLINE, useShizuku = false)
+    }
+}

--- a/app/src/main/java/com/gameocr/app/tile/CaptureTileService.kt
+++ b/app/src/main/java/com/gameocr/app/tile/CaptureTileService.kt
@@ -1,0 +1,257 @@
+package com.gameocr.app.tile
+
+import android.app.ActivityOptions
+import android.app.PendingIntent
+import android.content.Intent
+import android.graphics.drawable.Icon
+import android.net.Uri
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+import android.provider.Settings
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+import android.widget.Toast
+import android.annotation.SuppressLint
+import androidx.annotation.ChecksSdkIntAtLeast
+import androidx.core.content.ContextCompat
+import com.gameocr.app.R
+import com.gameocr.app.capture.MediaProjectionRequestActivity
+import com.gameocr.app.onboarding.OnboardingPrefs
+import com.gameocr.app.service.CaptureService
+import com.gameocr.app.service.CaptureServiceState
+import com.gameocr.app.shizuku.ShizukuCapabilities
+import com.gameocr.app.ui.MainActivity
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+import timber.log.Timber
+
+/** 快捷设置磁贴（issue #23）：只做 Android 胶水，路由判定全在纯策略里（例外只有失败兜底），好让上不了真机的接线仍能被 `*WiringTest` 锁住。 */
+@AndroidEntryPoint
+class CaptureTileService : TileService() {
+
+    @Inject lateinit var shizukuCapabilities: ShizukuCapabilities
+
+    /** 上次被接受的启动时刻。只在启动侧写入；挡住停止会让服务关不掉 —— 理由见 [shouldAcceptTileTrigger]。 */
+    private var lastAcceptedStartAtMs: Long? = null
+
+    private val watchHandler = Handler(Looper.getMainLooper())
+
+    /** 点击后仍在等结果的轮询；磁贴被销毁时要撤掉，否则会空转到窗口结束。 */
+    private var watchRunnable: Runnable? = null
+
+    /** 服务可能已在运行：不立刻渲染的话，系统给的默认 INACTIVE 会一直显示到下次点击。 */
+    override fun onTileAdded() {
+        super.onTileAdded()
+        renderTileState()
+    }
+
+    override fun onStartListening() {
+        super.onStartListening()
+        renderTileState()
+    }
+
+    override fun onDestroy() {
+        watchRunnable?.let(watchHandler::removeCallbacks)
+        watchRunnable = null
+        super.onDestroy()
+    }
+
+    override fun onClick() {
+        super.onClick()
+        val decision = decideCaptureStartRoute(
+            CaptureStartRouteInput(
+                setupCompleted = OnboardingPrefs.isCompleted(this),
+                // 必须回读校验，不能相信自己刚做的权限写入（appops 写入 ≠ 权限生效，因 OEM 而异）。
+                canDrawOverlay = Settings.canDrawOverlays(this),
+                serviceRunning = CaptureServiceState.running.value,
+                isLocked = isLocked(),
+                preferShizuku = preferShizuku(),
+            )
+        )
+        Timber.i("tile click → route=%s useShizuku=%s", decision.route, decision.useShizuku)
+
+        var startedDirectly = false
+        when (decision.route) {
+            CaptureStartRoute.STOP -> startService(CaptureService.stopIntent(this))
+
+            CaptureStartRoute.DIRECT_FGS ->
+                if (acceptStart()) startedDirectly = startCaptureDirect(decision.useShizuku)
+
+            CaptureStartRoute.TRAMPOLINE -> if (acceptStart()) launchProjectionGateway()
+
+            CaptureStartRoute.NEEDS_OVERLAY_PERMISSION -> openOverlayPermissionSettings()
+
+            CaptureStartRoute.BLOCKED_NEED_UNLOCK -> toast(R.string.tile_toast_unlock_first)
+
+            CaptureStartRoute.UNAVAILABLE -> openMainApp()
+        }
+        resolveTileClickState(decision.route, startedDirectly)?.let(::applyTileState)
+        if (routeStartsCaptureAttempt(decision.route)) watchStartOutcome()
+    }
+
+    /** 直连在 Android 12–14 未实测，失败必须回落授权窗，否则用户只看到「点了没反应」。返回值表示是否真的走上了直连。 */
+    private fun startCaptureDirect(useShizuku: Boolean): Boolean {
+        val intent = Intent(this, CaptureService::class.java).apply {
+            action = CaptureService.ACTION_START
+            putExtra(CaptureService.EXTRA_USE_SHIZUKU, useShizuku)
+        }
+        return try {
+            ContextCompat.startForegroundService(this, intent)
+            true
+        } catch (t: Throwable) {
+            Timber.w(t, "tile direct FGS rejected — falling back to MediaProjection gateway")
+            launchProjectionGateway()
+            false
+        }
+    }
+
+    /** 经 [MediaProjectionRequestActivity] 启动：由它弹系统授权框，拿到 token 后自己起服务。 */
+    private fun launchProjectionGateway() {
+        startActivityFromTile(MediaProjectionRequestActivity.newIntent(this))
+    }
+
+    private fun openOverlayPermissionSettings() {
+        toast(R.string.tile_toast_overlay_required)
+        startActivityFromTile(
+            Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION, Uri.parse("package:$packageName"))
+        )
+    }
+
+    private fun openMainApp() {
+        startActivityFromTile(Intent(this, MainActivity::class.java))
+    }
+
+    private fun renderTileState() {
+        val running = CaptureServiceState.running.value
+        val setupDone = OnboardingPrefs.isCompleted(this)
+        applyTileState(
+            resolveCaptureTileState(setupCompleted = setupDone, serviceRunning = running)
+        )
+    }
+
+    private fun applyTileState(state: CaptureTileState) {
+        val tile = qsTile ?: run {
+            Timber.i("tile render skipped: qsTile is null")
+            return
+        }
+        tile.state = when (state) {
+            CaptureTileState.ACTIVE -> Tile.STATE_ACTIVE
+            CaptureTileState.INACTIVE -> Tile.STATE_INACTIVE
+            CaptureTileState.UNAVAILABLE -> Tile.STATE_UNAVAILABLE
+        }
+        tile.label = getString(R.string.tile_capture_label)
+        tile.icon = Icon.createWithResource(this, R.drawable.ic_tile_capture)
+        tile.updateTile()
+        Timber.i("tile state applied → %s", state)
+    }
+
+    /** 磁贴是 SystemUI 的界面，普通 `startActivity` 会被后台启动限制静默拦下（无异常）。 */
+    private fun startActivityFromTile(target: Intent) {
+        val launch = Intent(target).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        if (launchNeedsPendingIntent(Build.VERSION.SDK_INT)) {
+            startActivityAndCollapse(pendingIntentFor(launch))
+        } else {
+            // API < 34 没有 PendingIntent 重载，只能用这个；它只在 targetSdk ≥ 34 时才会抛
+            // UnsupportedOperationException，而本分支已由 `launchNeedsPendingIntent` 限定在 34 以下。
+            @Suppress("DEPRECATION")
+            @SuppressLint("StartActivityAndCollapseDeprecated")
+            startActivityAndCollapse(launch)
+        }
+    }
+
+    private fun pendingIntentFor(launch: Intent): PendingIntent {
+        val flags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        // targetSdk ≥ 35 起创建方默认不再委派 BAL 权限，必须显式 opt-in，否则启动被静默拦下。
+        return if (launchNeedsCreatorOptIn(Build.VERSION.SDK_INT)) {
+            val options = ActivityOptions.makeBasic().apply {
+                setPendingIntentCreatorBackgroundActivityStartMode(
+                    ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_ALLOWED
+                )
+            }
+            PendingIntent.getActivity(
+                this,
+                TILE_LAUNCH_REQUEST_CODE,
+                launch,
+                flags,
+                options.toBundle(),
+            )
+        } else {
+            PendingIntent.getActivity(this, TILE_LAUNCH_REQUEST_CODE, launch, flags)
+        }
+    }
+
+    /** 把策略结论翻译成 lint 能读懂的 SDK 断言（lint 不认间接判断，会误报 `NewApi`）。 */
+    @ChecksSdkIntAtLeast(parameter = 0, api = TILE_PENDING_INTENT_MIN_SDK)
+    private fun launchNeedsPendingIntent(sdkInt: Int): Boolean =
+        resolveTileLaunchApi(sdkInt) == TileLaunchApi.PENDING_INTENT
+
+    /** 同上：`setPendingIntentCreatorBackgroundActivityStartMode` 需 API 34，靠这个注解让 lint 认账。 */
+    @ChecksSdkIntAtLeast(parameter = 0, api = PENDING_INTENT_CREATOR_OPT_IN_MIN_SDK)
+    private fun launchNeedsCreatorOptIn(sdkInt: Int): Boolean =
+        needsPendingIntentCreatorOptIn(sdkInt)
+
+    /** 去抖：接受则记下时刻。只在「启动」侧调用，停止侧永不调用。 */
+    private fun acceptStart(): Boolean {
+        val now = SystemClock.elapsedRealtime()
+        val accepted = shouldAcceptTileTrigger(lastAcceptedStartAtMs, now)
+        if (accepted) lastAcceptedStartAtMs = now
+        return accepted
+    }
+
+    /** 冷启时特权还在异步校验、读到的不是 READY，就走去授权窗 —— 宁可多弹一次框，也不赌一个跑不动 `screencap` 的 Shizuku。 */
+    private fun preferShizuku(): Boolean = try {
+        shizukuCapabilities.availability(this) == ShizukuCapabilities.Availability.READY
+    } catch (t: Throwable) {
+        Timber.w(t, "tile shizuku availability probe failed — falling back to MediaProjection")
+        false
+    }
+
+    /**
+     * 有界轮询启动结果：超时什么都不写（保留乐观值，理由见 [resolveTilePostClickState]），窗口须盖住
+     * 服务最坏结算耗时，且只在结论变化时写，以免逐帧白打 SystemUI binder。
+     */
+    private fun watchStartOutcome() {
+        val stoppedAtClick = CaptureServiceState.stoppedWithoutRunning.value
+        var remaining = TILE_START_WATCH_ATTEMPTS
+        var lastWritten: CaptureTileState? = null
+        val tick = object : Runnable {
+            override fun run() {
+                val verdict = resolveTilePostClickState(
+                    serviceRunning = CaptureServiceState.running.value,
+                    stoppedWithoutRunningSinceClick =
+                        CaptureServiceState.stoppedWithoutRunning.value > stoppedAtClick,
+                )
+                if (verdict != null && verdict != lastWritten) {
+                    applyTileState(verdict)
+                    lastWritten = verdict
+                }
+                if (--remaining > 0) {
+                    watchHandler.postDelayed(this, TILE_START_WATCH_INTERVAL_MS)
+                } else {
+                    watchRunnable = null
+                }
+            }
+        }
+        watchRunnable?.let(watchHandler::removeCallbacks)
+        watchRunnable = tick
+        watchHandler.postDelayed(tick, TILE_START_WATCH_INTERVAL_MS)
+    }
+
+    private fun toast(resId: Int) {
+        Toast.makeText(this, resId, Toast.LENGTH_SHORT).show()
+    }
+
+    private companion object {
+        const val TILE_LAUNCH_REQUEST_CODE = 0x7A11
+
+        /**
+         * 轮询窗口 = 12s。必须盖住服务最坏情况的结算耗时：Shizuku dry-run 失败后服务还要等 8.5s
+         * 让用户读完错误条才 `stopSelf()`（`CaptureService`），窗口短于它就永远看不到那次停止，
+         * 磁贴在面板开着期间会一直停在 ACTIVE。
+         */
+        const val TILE_START_WATCH_ATTEMPTS = 48
+        const val TILE_START_WATCH_INTERVAL_MS = 250L
+    }
+}

--- a/app/src/main/java/com/gameocr/app/tile/TileClickStatePolicy.kt
+++ b/app/src/main/java/com/gameocr/app/tile/TileClickStatePolicy.kt
@@ -1,0 +1,26 @@
+package com.gameocr.app.tile
+
+/**
+ * 一次点击之后磁贴该自己写下的终值；`null` 表示保留 `onStartListening` 已渲染的值。点击后没有第二次
+ * 刷新机会（停止与直连都不收起面板，磁贴仍在监听，服务随后的 `requestListeningState` 会被系统吞掉
+ * —— 已在监听时系统不再回调 `onStartListening`），所以必须在这里定死；调用约定是分发完路由动作之后
+ * **无条件**调用一次 —— 写进各分支里的话，将来新增路由漏写一处不会有任何提示，磁贴会一直停在旧状态。
+ *
+ * @param directStartSucceeded 只有 [CaptureStartRoute.DIRECT_FGS] 会读它；降级走授权窗时传 `false`。
+ */
+internal fun resolveTileClickState(
+    route: CaptureStartRoute,
+    directStartSucceeded: Boolean,
+): CaptureTileState? = when (route) {
+    // 停止是异步的：此刻回读必然拿到陈旧的 true，只能在这里写死。
+    CaptureStartRoute.STOP -> CaptureTileState.INACTIVE
+    // 直连不收起面板 ⇒ 同 STOP；降级走授权窗时不写 —— 面板会收起，服务那时的刷新通知是有效的。
+    CaptureStartRoute.DIRECT_FGS ->
+        if (directStartSucceeded) CaptureTileState.ACTIVE else null
+    // 这四个分支要么会收起面板（跳 Activity），要么压根不改运行状态，留着已渲染的值即可。
+    CaptureStartRoute.TRAMPOLINE,
+    CaptureStartRoute.BLOCKED_NEED_UNLOCK,
+    CaptureStartRoute.NEEDS_OVERLAY_PERMISSION,
+    CaptureStartRoute.UNAVAILABLE,
+    -> null
+}

--- a/app/src/main/java/com/gameocr/app/tile/TileLaunchPolicy.kt
+++ b/app/src/main/java/com/gameocr/app/tile/TileLaunchPolicy.kt
@@ -1,0 +1,18 @@
+package com.gameocr.app.tile
+
+/** 两个重载缺一必崩：≥34 用 `PendingIntent`（`Intent` 那时会抛异常），<34 只能用废弃的 `Intent`（另一个不存在）。 */
+internal enum class TileLaunchApi {
+    LEGACY_INTENT,
+    PENDING_INTENT,
+}
+
+internal const val TILE_PENDING_INTENT_MIN_SDK = 34
+
+internal fun resolveTileLaunchApi(sdkInt: Int): TileLaunchApi =
+    if (sdkInt >= TILE_PENDING_INTENT_MIN_SDK) TileLaunchApi.PENDING_INTENT else TileLaunchApi.LEGACY_INTENT
+
+/** targetSdk ≥ 35 起创建方默认不再委派 BAL 权限，缺了会静默拦下（Logcat 只有 `Background activity launch blocked!`）。 */
+internal const val PENDING_INTENT_CREATOR_OPT_IN_MIN_SDK = 34
+
+internal fun needsPendingIntentCreatorOptIn(sdkInt: Int): Boolean =
+    sdkInt >= PENDING_INTENT_CREATOR_OPT_IN_MIN_SDK

--- a/app/src/main/java/com/gameocr/app/tile/TilePostClickStatePolicy.kt
+++ b/app/src/main/java/com/gameocr/app/tile/TilePostClickStatePolicy.kt
@@ -1,0 +1,19 @@
+package com.gameocr.app.tile
+
+/** 这两条路由会去启动服务（异步，有结果可等）；其余要么停服务、要么跳别的界面，没有可等的东西。 */
+internal fun routeStartsCaptureAttempt(route: CaptureStartRoute): Boolean =
+    route == CaptureStartRoute.DIRECT_FGS || route == CaptureStartRoute.TRAMPOLINE
+
+/**
+ * 点击启动之后磁贴该补写的状态；`null` 表示保留点击时写的值。不能用「等够时间就当失败」来判失败：
+ * 显示 INACTIVE 而服务其实在跑时，用户再点一次会被路由成 STOP 把服务关掉；反过来显示 ACTIVE 而服务
+ * 没跑，再点一次只是重试。所以只认服务主动报过的失败，结果未知就什么都不写。
+ */
+internal fun resolveTilePostClickState(
+    serviceRunning: Boolean,
+    stoppedWithoutRunningSinceClick: Boolean,
+): CaptureTileState? = when {
+    serviceRunning -> CaptureTileState.ACTIVE
+    stoppedWithoutRunningSinceClick -> CaptureTileState.INACTIVE
+    else -> null
+}

--- a/app/src/main/java/com/gameocr/app/tile/TileRefresh.kt
+++ b/app/src/main/java/com/gameocr/app/tile/TileRefresh.kt
@@ -1,0 +1,16 @@
+package com.gameocr.app.tile
+
+import android.content.ComponentName
+import android.content.Context
+import android.service.quicksettings.TileService
+import timber.log.Timber
+
+/** 请系统重绑磁贴重读状态。磁贴已在监听时该请求会被系统吞掉 —— 点击后不收起面板正属此况。 */
+internal fun requestCaptureTileRefresh(context: Context) {
+    runCatching {
+        TileService.requestListeningState(
+            context,
+            ComponentName(context, CaptureTileService::class.java),
+        )
+    }.onFailure { Timber.d(it, "tile refresh request ignored") }
+}

--- a/app/src/main/java/com/gameocr/app/tile/TileStatePolicy.kt
+++ b/app/src/main/java/com/gameocr/app/tile/TileStatePolicy.kt
@@ -1,0 +1,18 @@
+package com.gameocr.app.tile
+
+/** 保持零 Android 依赖（不直接用 `Tile.STATE_*`），才能放进纯 JVM 单测。 */
+internal enum class CaptureTileState {
+    ACTIVE,
+    INACTIVE,
+    UNAVAILABLE,
+}
+
+/** 不因「Shizuku 未就绪」置 UNAVAILABLE —— 那时会降级走 MediaProjection，磁贴依然可用。 */
+internal fun resolveCaptureTileState(
+    setupCompleted: Boolean,
+    serviceRunning: Boolean,
+): CaptureTileState = when {
+    !setupCompleted -> CaptureTileState.UNAVAILABLE
+    serviceRunning -> CaptureTileState.ACTIVE
+    else -> CaptureTileState.INACTIVE
+}

--- a/app/src/main/java/com/gameocr/app/tile/TileTriggerThrottlePolicy.kt
+++ b/app/src/main/java/com/gameocr/app/tile/TileTriggerThrottlePolicy.kt
@@ -1,0 +1,16 @@
+package com.gameocr.app.tile
+
+/** 磁贴连点抑制窗口。 */
+internal const val TILE_TRIGGER_MIN_INTERVAL_MS = 800L
+
+/** 连点会让启动重跑 `handleStart()` 重建悬浮球；**只约束启动**，挡住停止会让服务变成关不掉的僵尸。 */
+internal fun shouldAcceptTileTrigger(
+    lastAcceptedAtMs: Long?,
+    nowMs: Long,
+): Boolean {
+    if (lastAcceptedAtMs == null) return true
+    // 防御分支：调用方传的是 `SystemClock.elapsedRealtime()`（单调，不随墙钟倒退），所以实际不可达。
+    // 留着是为了将来若换成墙钟计时，不会把磁贴永久锁死。
+    if (nowMs < lastAcceptedAtMs) return true
+    return nowMs - lastAcceptedAtMs >= TILE_TRIGGER_MIN_INTERVAL_MS
+}

--- a/app/src/main/java/com/gameocr/app/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/gameocr/app/ui/SettingsScreen.kt
@@ -758,7 +758,8 @@ fun SettingsScreen(
 
     // dirty 检测：load 时 capture 一份初始 Settings，之后跟 buildSnapshot() 比 equals。
     // 旧版手写两份 List<Any?>，每加 Settings 字段都要在两个 list 同步加，反复犯"忘改一边"的 bug。
-    // 现在用 data class equals 自动覆盖所有字段——加字段只改 buildSnapshot() 一处。
+    // data class equals 让 dirty 检测不再需要并列清单；但**表单字段仍有两份**：buildSnapshot() 覆盖草稿，
+    // save() 落盘，两边必须逐字段对齐 —— 由 buildSnapshotFields_andSaveFields_coverEachOther 守着。
     var initialSettings by remember { mutableStateOf<Settings?>(null) }
     var showUnsavedDialog by remember { mutableStateOf(false) }
     var showSakuraFallbackDialog by remember { mutableStateOf(false) }
@@ -1590,7 +1591,10 @@ fun SettingsScreen(
             baiduFanyiAppId = baiduFanyiAppId,
             baiduFanyiSecretKey = baiduFanyiSecret,
             overlayFonts = overlayFontEntries,
-            activeTranslationPresetId = currentMatchingTranslationPresetId()
+            activeTranslationPresetId = currentMatchingTranslationPresetId(),
+            // 最近用过的端上源语言也是表单草稿（选一次就重排）；必须跟保存路径一起落盘，否则
+            // buildSnapshot() 把它算进 dirty、UI 报告"已保存"，而持久值从头到尾没变过。
+            mlKitRecentSourceLanguages = mlKitRecentSources
         )
     }
 

--- a/app/src/main/java/com/gameocr/app/ui/SettingsViewModel.kt
+++ b/app/src/main/java/com/gameocr/app/ui/SettingsViewModel.kt
@@ -412,7 +412,8 @@ class SettingsViewModel @Inject constructor(
         baiduFanyiAppId: String,
         baiduFanyiSecretKey: String,
         overlayFonts: List<OverlayFontEntry>,
-        activeTranslationPresetId: String
+        activeTranslationPresetId: String,
+        mlKitRecentSourceLanguages: List<String>,
     ) {
         repo.update {
             it.copy(
@@ -543,7 +544,8 @@ class SettingsViewModel @Inject constructor(
                 baiduFanyiAppId = baiduFanyiAppId.trim(),
                 baiduFanyiSecretKey = baiduFanyiSecretKey.trim(),
                 overlayFonts = overlayFonts,
-                activeTranslationPresetId = activeTranslationPresetId
+                activeTranslationPresetId = activeTranslationPresetId,
+                mlKitRecentSourceLanguages = mlKitRecentSourceLanguages
             )
         }
     }

--- a/app/src/main/res/drawable/ic_tile_capture.xml
+++ b/app/src/main/res/drawable/ic_tile_capture.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- 跟主球同款「双向翻译箭头」(ic_overlay_button 同 path)。磁贴图标由系统统一染色，这里只提供形状。 -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M6.99,11L3,15l3.99,4v-3H14v-2H6.99v-3zM21,9l-3.99,-4v3H10v2h7.01v3L21,9z" />
+</vector>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1942,4 +1942,8 @@
     <string name="source_preservation_delete_message">“%1$s”下次识别时将恢复普通翻译，并可能被涂抹替换。</string>
     <string name="translation_library_help_preserve_title">保留原文字效</string>
     <string name="translation_library_help_preserve_body">OCR 文本块精确命中后，不翻译、不显示，也不涂抹原图。适合把日漫拟声词字形作为画面的一部分保留。匹配会忽略空白和安全的首尾标点，但不会进行模糊匹配或包含匹配。</string>
+    <!-- 快捷设置磁贴（QS Tile）：一键启动/停止截屏服务 -->
+    <string name="tile_capture_label">屏译</string>
+    <string name="tile_toast_overlay_required">请先授予「显示在其他应用上层」权限</string>
+    <string name="tile_toast_unlock_first">请先解锁设备</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1944,4 +1944,8 @@
     <string name="source_preservation_delete_message">“%1$s” will be translated normally and may be replaced the next time it is recognized.</string>
     <string name="translation_library_help_preserve_title">Keep source artwork</string>
     <string name="translation_library_help_preserve_body">An exact OCR-block match is not translated, displayed, or erased. This is intended for manga sound effects whose original lettering is part of the artwork. Matching ignores whitespace and safe edge punctuation, but never uses fuzzy or substring matching.</string>
+    <!-- 快捷设置磁贴（QS Tile）：一键启动/停止截屏服务 -->
+    <string name="tile_capture_label">Screen Translator</string>
+    <string name="tile_toast_overlay_required">Grant the “Display over other apps” permission first</string>
+    <string name="tile_toast_unlock_first">Unlock the device first</string>
 </resources>

--- a/app/src/test/java/com/gameocr/app/data/SettingsCoverageAuditTest.kt
+++ b/app/src/test/java/com/gameocr/app/data/SettingsCoverageAuditTest.kt
@@ -141,6 +141,49 @@ class SettingsCoverageAuditTest {
         )
     }
 
+    /**
+     * `buildSnapshot()` 只覆盖 UI 上真正编辑的表单字段，`save()` 只写入同一批字段。两份清单必须
+     * 逐字段对齐：快照里有、`save()` 里没有 ⇒ 编辑被静默丢弃（dirty 由快照重置，UI 报告"已保存"，
+     * 而持久值从未改变）；反过来则说明有字段带着陈旧值落盘。别用"某个字段名在文件里出现过"这种
+     * 弱断言 —— 两侧都各自列了一百多个字段，只有逐字段集合比对才能发现单边漏改。
+     */
+    @Test
+    fun buildSnapshotFields_andSaveFields_coverEachOther() {
+        val settingsScreenSource = sourceFile("src/main/java/com/gameocr/app/ui/SettingsScreen.kt").readText()
+        val viewModelSource = sourceFile("src/main/java/com/gameocr/app/ui/SettingsViewModel.kt").readText()
+
+        val snapshotFields = copyArgumentNames(
+            settingsScreenSource,
+            "fun buildSnapshot(): Settings = (initialSettings ?: Settings()).copy(",
+        )
+        // 锚点必须落在 `save()` 这个整表单函数上。ViewModel 里另有一批单字段 setter 也写
+        // `repo.update { it.copy(x = ...) }`，若锚点漂到它们上面，比对会退化成"两个小集合相等"而假绿。
+        val savedFields = copyArgumentNames(viewModelSource, "suspend fun save(")
+
+        // 两个集合都必须确实是**整表单**；否则下面两条断言比的是无关字段集，会静默通过。
+        listOf("snapshot" to snapshotFields, "save" to savedFields).forEach { (label, fields) ->
+            assertTrue(
+                "the $label anchor resolved the wrong `.copy(` — this test would then compare two " +
+                    "unrelated field sets and pass: ${fields.size} fields",
+                fields.contains(WHOLE_FORM_SENTINEL),
+            )
+        }
+
+        val overlaidButNotSaved = snapshotFields - savedFields
+        assertTrue(
+            "buildSnapshot overlays fields that save() never writes, so the edit is silently dropped: " +
+                overlaidButNotSaved,
+            overlaidButNotSaved.isEmpty(),
+        )
+
+        val savedButNotOverlaid = savedFields - snapshotFields
+        assertEquals(
+            "save() writes fields the snapshot never overlays; add each to SAVE_ONLY_FIELDS with a reason",
+            SAVE_ONLY_FIELDS,
+            savedButNotOverlaid,
+        )
+    }
+
     private fun sourceFile(path: String): File =
         listOf(File(path), File("app", path)).firstOrNull { it.isFile }
             ?: error("Source file not found: $path")
@@ -183,4 +226,62 @@ class SettingsCoverageAuditTest {
 
     private fun wordPattern(field: String): Regex =
         Regex("""\b${Regex.escape(field)}\b""")
+
+    /** 取出 `marker` 之后第一个 `.copy(...)` 的顶层具名实参名。按括号深度切分，跨行与 CRLF 都不影响。 */
+    private fun copyArgumentNames(source: String, marker: String): Set<String> {
+        val markerIndex = source.indexOf(marker)
+        require(markerIndex >= 0) { "Missing marker: $marker" }
+        val copyIndex = source.indexOf(".copy(", markerIndex)
+        require(copyIndex >= 0) { "Missing .copy( after: $marker" }
+        val openParen = copyIndex + ".copy".length
+        val body = source.substring(openParen + 1, matchingParenIndex(source, openParen))
+        return topLevelArgumentNames(body)
+    }
+
+    private fun topLevelArgumentNames(body: String): Set<String> {
+        val names = linkedSetOf<String>()
+        val argument = StringBuilder()
+        var depth = 0
+        var index = 0
+        while (index < body.length) {
+            val char = body[index]
+            // 注释里的括号不该参与配对。
+            if (char == '/' && index + 1 < body.length && body[index + 1] == '/') {
+                while (index < body.length && body[index] != '\n') index++
+                continue
+            }
+            when (char) {
+                '(', '[', '{' -> depth++
+                ')', ']', '}' -> depth--
+                ',' -> if (depth == 0) {
+                    argumentName(argument.toString())?.let(names::add)
+                    argument.clear()
+                    index++
+                    continue
+                }
+            }
+            argument.append(char)
+            index++
+        }
+        argumentName(argument.toString())?.let(names::add)
+        return names
+    }
+
+    private fun argumentName(argument: String): String? =
+        Regex("""^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=""")
+            .find(argument)
+            ?.groupValues
+            ?.get(1)
+
+    private companion object {
+        /**
+         * 只被 `save()` 写入、快照有意不覆盖的字段。`activeTranslationPresetId` 在保存时由
+         * `currentMatchingTranslationPresetId()` 现算（见 SettingsScreen 的 doSave），不是表单草稿，
+         * 所以快照不覆盖它是对的。
+         */
+        val SAVE_ONLY_FIELDS = setOf("activeTranslationPresetId")
+
+        /** 整表单 copy 必然包含的字段，用来证明锚点没有落到某个单字段 setter 上。 */
+        const val WHOLE_FORM_SENTINEL = "baseUrl"
+    }
 }

--- a/app/src/test/java/com/gameocr/app/service/CaptureStartRecoveryPolicyTest.kt
+++ b/app/src/test/java/com/gameocr/app/service/CaptureStartRecoveryPolicyTest.kt
@@ -1,0 +1,82 @@
+package com.gameocr.app.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CaptureStartRecoveryPolicyTest {
+
+    @Test
+    fun recovery_tableDriven_handsOffOnlyTheTokenlessShizukuRequest() {
+        data class Case(
+            val name: String,
+            val tokenPresent: Boolean,
+            val shizukuRequested: Boolean,
+            val expected: CaptureStartRecovery,
+        )
+
+        listOf(
+            Case(
+                "direct start lost the Shizuku race",
+                tokenPresent = false,
+                shizukuRequested = true,
+                expected = CaptureStartRecovery.OPEN_PROJECTION_GATEWAY,
+            ),
+            Case(
+                "gateway start failed again",
+                tokenPresent = true,
+                shizukuRequested = false,
+                expected = CaptureStartRecovery.NONE,
+            ),
+            Case(
+                "no token and no Shizuku request",
+                tokenPresent = false,
+                shizukuRequested = false,
+                expected = CaptureStartRecovery.NONE,
+            ),
+            Case(
+                "token present despite a Shizuku request",
+                tokenPresent = true,
+                shizukuRequested = true,
+                expected = CaptureStartRecovery.NONE,
+            ),
+        ).forEach { case ->
+            assertEquals(
+                "${case.name}: tokenPresent=${case.tokenPresent} shizukuRequested=${case.shizukuRequested}",
+                case.expected,
+                decideCaptureStartRecovery(
+                    CaptureStartRecoveryInput(case.tokenPresent, case.shizukuRequested)
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun aStartThatAlreadyCameFromTheGatewayNeverReopensIt() {
+        val reopened = listOf(false, true).filter { shizukuRequested ->
+            decideCaptureStartRecovery(
+                CaptureStartRecoveryInput(tokenPresent = true, shizukuRequested = shizukuRequested)
+            ) == CaptureStartRecovery.OPEN_PROJECTION_GATEWAY
+        }
+        assertEquals(
+            "a token-bearing intent was started by the gateway itself: reopening it would bounce the " +
+                "user between the system dialog and a failing service forever",
+            emptyList<Boolean>(),
+            reopened,
+        )
+    }
+
+    @Test
+    fun onlyTheDirectStartEverNeedsAnIntervention() {
+        val intervenes = listOf(false, true).filter { tokenPresent ->
+            decideCaptureStartRecovery(
+                CaptureStartRecoveryInput(tokenPresent = tokenPresent, shizukuRequested = true)
+            ) == CaptureStartRecovery.OPEN_PROJECTION_GATEWAY
+        }
+        assertEquals(
+            "the tile is the only caller that requests Shizuku without a token, so it must be the only " +
+                "one the service intervenes for",
+            listOf(false),
+            intervenes,
+        )
+    }
+}

--- a/app/src/test/java/com/gameocr/app/tile/CaptureStartRoutePolicyTest.kt
+++ b/app/src/test/java/com/gameocr/app/tile/CaptureStartRoutePolicyTest.kt
@@ -1,0 +1,192 @@
+package com.gameocr.app.tile
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CaptureStartRoutePolicyTest {
+
+    private fun input(
+        setupCompleted: Boolean = true,
+        canDrawOverlay: Boolean = true,
+        serviceRunning: Boolean = false,
+        isLocked: Boolean = false,
+        preferShizuku: Boolean = true,
+    ) = CaptureStartRouteInput(
+        setupCompleted = setupCompleted,
+        canDrawOverlay = canDrawOverlay,
+        serviceRunning = serviceRunning,
+        isLocked = isLocked,
+        preferShizuku = preferShizuku,
+    )
+
+    @Test
+    fun route_tableDriven_matchesThePriorityOrder() {
+        data class Case(
+            val name: String,
+            val input: CaptureStartRouteInput,
+            val expectedRoute: CaptureStartRoute,
+            val expectedUseShizuku: Boolean,
+        )
+
+        listOf(
+            Case(
+                "incomplete setup is unavailable",
+                input(setupCompleted = false), CaptureStartRoute.UNAVAILABLE, false,
+            ),
+            Case(
+                "incomplete setup wins over a running service",
+                input(setupCompleted = false, serviceRunning = true),
+                CaptureStartRoute.UNAVAILABLE, false,
+            ),
+            Case(
+                "incomplete setup wins over the lock screen",
+                input(setupCompleted = false, isLocked = true),
+                CaptureStartRoute.UNAVAILABLE, false,
+            ),
+
+            Case(
+                "a running service stops when Shizuku is preferred",
+                input(serviceRunning = true), CaptureStartRoute.STOP, false,
+            ),
+            Case(
+                "a running service stops on the projection path",
+                input(serviceRunning = true, preferShizuku = false), CaptureStartRoute.STOP, false,
+            ),
+            Case(
+                "a running service stops even while locked",
+                input(serviceRunning = true, isLocked = true), CaptureStartRoute.STOP, false,
+            ),
+            Case(
+                "a running service stops after the overlay permission was revoked",
+                input(serviceRunning = true, canDrawOverlay = false),
+                CaptureStartRoute.STOP, false,
+            ),
+
+            Case(
+                "a missing overlay permission is reported first",
+                input(canDrawOverlay = false), CaptureStartRoute.NEEDS_OVERLAY_PERMISSION, false,
+            ),
+            Case(
+                "a missing overlay permission wins over ready Shizuku",
+                input(canDrawOverlay = false, preferShizuku = true),
+                CaptureStartRoute.NEEDS_OVERLAY_PERMISSION, false,
+            ),
+            Case(
+                "a missing overlay permission wins over the lock screen",
+                input(canDrawOverlay = false, isLocked = true),
+                CaptureStartRoute.NEEDS_OVERLAY_PERMISSION, false,
+            ),
+
+            Case(
+                "ready Shizuku starts the foreground service directly",
+                input(preferShizuku = true), CaptureStartRoute.DIRECT_FGS, true,
+            ),
+            Case(
+                "ready Shizuku still starts directly while locked",
+                input(preferShizuku = true, isLocked = true), CaptureStartRoute.DIRECT_FGS, true,
+            ),
+
+            Case(
+                "unavailable Shizuku falls back to the projection gateway",
+                input(preferShizuku = false), CaptureStartRoute.TRAMPOLINE, false,
+            ),
+            Case(
+                "unavailable Shizuku while locked asks to unlock first",
+                input(preferShizuku = false, isLocked = true),
+                CaptureStartRoute.BLOCKED_NEED_UNLOCK, false,
+            ),
+        ).forEach { case ->
+            val actual = decideCaptureStartRoute(case.input)
+            assertEquals(case.name, case.expectedRoute, actual.route)
+            assertEquals(case.name, case.expectedUseShizuku, actual.useShizuku)
+        }
+    }
+
+    @Test
+    fun shizukuUnavailable_mustNotBlockTheTile() {
+        // Shizuku is unavailable by default after every reboot for non-root users,
+        // so the tile must fall back instead of refusing.
+        val decision = decideCaptureStartRoute(input(preferShizuku = false))
+        assertTrue(
+            "unavailable Shizuku must not yield UNAVAILABLE",
+            decision.route != CaptureStartRoute.UNAVAILABLE,
+        )
+        assertFalse("the fallback must not use Shizuku", decision.useShizuku)
+        assertEquals(CaptureStartRoute.TRAMPOLINE, decision.route)
+    }
+
+    @Test
+    fun missingOverlayPermission_mustNotBlockStop() {
+        assertEquals(
+            CaptureStartRoute.STOP,
+            decideCaptureStartRoute(
+                input(serviceRunning = true, canDrawOverlay = false),
+            ).route,
+        )
+        assertEquals(
+            CaptureStartRoute.NEEDS_OVERLAY_PERMISSION,
+            decideCaptureStartRoute(
+                input(serviceRunning = false, canDrawOverlay = false),
+            ).route,
+        )
+    }
+
+    @Test
+    fun tileIsAToggle_onServiceRunning() {
+        val running = decideCaptureStartRoute(input(serviceRunning = true))
+        val idle = decideCaptureStartRoute(input(serviceRunning = false))
+        assertEquals(CaptureStartRoute.STOP, running.route)
+        assertTrue(
+            "an idle service must not yield STOP",
+            idle.route != CaptureStartRoute.STOP,
+        )
+    }
+
+    @Test
+    fun useShizuku_onlyWhenEveryPreconditionHolds() {
+        listOf(true, false).forEach { setup ->
+            listOf(true, false).forEach { overlay ->
+                listOf(true, false).forEach { running ->
+                    listOf(true, false).forEach { locked ->
+                        listOf(true, false).forEach { prefer ->
+                            val decision = decideCaptureStartRoute(
+                                input(setup, overlay, running, locked, prefer),
+                            )
+                            val expected = setup && overlay && !running && prefer
+                            assertEquals(
+                                "setup=$setup overlay=$overlay running=$running " +
+                                    "locked=$locked prefer=$prefer",
+                                expected,
+                                decision.useShizuku,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun lockedOnlyBlocksTheMediaProjectionPath() {
+        assertEquals(
+            CaptureStartRoute.DIRECT_FGS,
+            decideCaptureStartRoute(input(isLocked = true, preferShizuku = true)).route,
+        )
+        assertEquals(
+            CaptureStartRoute.STOP,
+            decideCaptureStartRoute(input(serviceRunning = true, isLocked = true)).route,
+        )
+        assertEquals(
+            CaptureStartRoute.BLOCKED_NEED_UNLOCK,
+            decideCaptureStartRoute(input(isLocked = true, preferShizuku = false)).route,
+        )
+        assertEquals(
+            CaptureStartRoute.NEEDS_OVERLAY_PERMISSION,
+            decideCaptureStartRoute(
+                input(isLocked = true, preferShizuku = false, canDrawOverlay = false),
+            ).route,
+        )
+    }
+}

--- a/app/src/test/java/com/gameocr/app/tile/CaptureTileIconTest.kt
+++ b/app/src/test/java/com/gameocr/app/tile/CaptureTileIconTest.kt
@@ -1,0 +1,74 @@
+package com.gameocr.app.tile
+
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.w3c.dom.Element
+
+/**
+ * 磁贴图标是 Manifest 里的一个字符串引用，删掉或改尺寸都由编译器放行、真机上才看得出来，所以锁住它。
+ * 可信度前置同 [CaptureTileManifestTest]：res 下的改动不在单测依赖图上，缺了源码输入声明即假绿。
+ */
+class CaptureTileIconTest {
+
+    @Test
+    fun theIconTheManifestReferencesExists() {
+        val icon = tileServiceIcon()
+        val name = icon.removePrefix("@drawable/")
+        val file = sourceFile("src/main/res/drawable/$name.xml")
+
+        assertEquals(
+            "the manifest icon must point at a drawable that is actually in res/drawable",
+            true,
+            file.isFile,
+        )
+    }
+
+    @Test
+    fun theIconIsTheTilesOwn24dpVariant() {
+        // 24dp 是本文件存在的**唯一理由**：主球图标 ic_overlay_button 是 48dp，当成磁贴图标会偏大。
+        // 若哪天有人把这份尺寸改成 48dp，二者就完全等价了，应当合并成一个文件。
+        val vector = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+            .parse(sourceFile("src/main/res/drawable/ic_tile_capture.xml")).documentElement
+
+        assertEquals("the drawable must be a <vector>", "vector", vector.tagName)
+        assertEquals("android:width", "24dp", vector.getAttribute("android:width"))
+        assertEquals("android:height", "24dp", vector.getAttribute("android:height"))
+    }
+
+    @Test
+    fun theIconActuallyDrawsSomething() {
+        val paths = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+            .parse(sourceFile("src/main/res/drawable/ic_tile_capture.xml"))
+            .getElementsByTagName("path")
+
+        assertTrue(
+            "an icon with no <path> renders as a blank tile slot",
+            paths.length >= 1,
+        )
+        assertEquals(
+            "the path must carry actual geometry, not an empty placeholder",
+            false,
+            (paths.item(0) as Element).getAttribute("android:pathData").isBlank(),
+        )
+    }
+
+    private fun tileServiceIcon(): String {
+        val document = DocumentBuilderFactory.newInstance()
+            .newDocumentBuilder()
+            .parse(sourceFile("src/main/AndroidManifest.xml"))
+        val services = document.getElementsByTagName("service")
+        val tile = (0 until services.length)
+            .map { services.item(it) as Element }
+            .firstOrNull { it.getAttribute("android:name").endsWith("CaptureTileService") }
+            ?: error("tile service declaration not found in AndroidManifest.xml")
+        return tile.getAttribute("android:icon")
+    }
+
+    // Paths are relative to the module root; both candidates cover the repo-root and app/ working directories.
+    private fun sourceFile(path: String): File = listOf(File(path), File("app", path))
+        .firstOrNull(File::isFile)
+        ?: File(path)
+}

--- a/app/src/test/java/com/gameocr/app/tile/CaptureTileManifestTest.kt
+++ b/app/src/test/java/com/gameocr/app/tile/CaptureTileManifestTest.kt
@@ -1,0 +1,105 @@
+package com.gameocr.app.tile
+
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.w3c.dom.Element
+
+/**
+ * 磁贴声明上不了真机就验证不了，但每一条声明漏掉都是静默失效，所以逐条断言。可信度前置见
+ * `app/build.gradle.kts` 的源码输入声明：AndroidManifest.xml 不在单测 classpath 上，缺了它本测试
+ * 会复用陈旧结果、用绿灯冒充通过，摘除那条声明即等于让本文件失去意义。
+ */
+class CaptureTileManifestTest {
+
+    @Test
+    fun tileService_isDeclaredWithSystemBindPermission() {
+        val service = tileServiceNode()
+
+        assertEquals("exported", "true", service.getAttribute("android:exported"))
+        assertEquals(
+            "bind permission",
+            "android.permission.BIND_QUICK_SETTINGS_TILE",
+            service.getAttribute("android:permission"),
+        )
+        assertEquals("label", "@string/tile_capture_label", service.getAttribute("android:label"))
+        assertEquals("icon", "@drawable/ic_tile_capture", service.getAttribute("android:icon"))
+    }
+
+    @Test
+    fun tileService_declaresQuickSettingsTileAction() {
+        val actions = tileServiceNode().getElementsByTagName("action")
+        val declared = (0 until actions.length).map { actions.item(it) as Element }
+            .map { it.getAttribute("android:name") }
+
+        assertTrue(
+            "missing the QS_TILE action, so the system would not treat this as a tile: $declared",
+            declared.contains("android.service.quicksettings.action.QS_TILE"),
+        )
+    }
+
+    @Test
+    fun tileService_declaresActiveTileMetadata() {
+        val metadata = tileServiceNode().getElementsByTagName("meta-data")
+        val pairs = (0 until metadata.length)
+            .map { metadata.item(it) as Element }
+            .map { it.getAttribute("android:name") to it.getAttribute("android:value") }
+
+        assertTrue(
+            "missing ACTIVE_TILE=true, which makes requestListeningState a silent no-op: $pairs",
+            pairs.contains("android.service.quicksettings.ACTIVE_TILE" to "true"),
+        )
+    }
+
+    @Test
+    fun tileService_declaresToggleableTileMetadata() {
+        val metadata = tileServiceNode().getElementsByTagName("meta-data")
+        val pairs = (0 until metadata.length)
+            .map { metadata.item(it) as Element }
+            .map { it.getAttribute("android:name") to it.getAttribute("android:value") }
+
+        assertTrue(
+            "missing TOGGLEABLE_TILE=true, so the panel would not render the on/off states that " +
+                "this tile actually has: $pairs",
+            pairs.contains("android.service.quicksettings.TOGGLEABLE_TILE" to "true"),
+        )
+    }
+
+    @Test
+    fun tileService_manifestNameMatchesTheRealClassName() {
+        // The manifest uses a relative name resolved against the namespace, so compare the resolved form.
+        val namespace = namespaceFromGradle()
+        val declaredName = tileServiceNode().getAttribute("android:name")
+        val resolved = if (declaredName.startsWith(".")) namespace + declaredName else declaredName
+
+        assertEquals(CaptureTileService::class.java.name, resolved)
+    }
+
+    private fun namespaceFromGradle(): String {
+        val gradle = sourceFile("build.gradle.kts").readText()
+        return Regex("""^\s*namespace\s*=\s*"([^"]+)"""", RegexOption.MULTILINE)
+            .find(gradle)
+            ?.groupValues
+            ?.get(1)
+            ?: error("namespace not found in app/build.gradle.kts")
+    }
+
+    private fun tileServiceNode(): Element {
+        val document = DocumentBuilderFactory.newInstance()
+            .newDocumentBuilder()
+            .parse(sourceFile("src/main/AndroidManifest.xml"))
+        val services = document.getElementsByTagName("service")
+        return (0 until services.length)
+            .map { services.item(it) as Element }
+            .firstOrNull {
+                it.getAttribute("android:name").endsWith("CaptureTileService")
+            }
+            ?: error("tile service declaration not found in AndroidManifest.xml")
+    }
+
+    private fun sourceFile(path: String): File = listOf(File(path), File("app", path))
+        .firstOrNull(File::isFile)
+        ?: error("Source file not found: $path")
+}

--- a/app/src/test/java/com/gameocr/app/tile/CaptureTileStringsTest.kt
+++ b/app/src/test/java/com/gameocr/app/tile/CaptureTileStringsTest.kt
@@ -1,0 +1,97 @@
+package com.gameocr.app.tile
+
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * 两种语言的 values 目录是手写的两份，漏一份在真机上很难注意到，所以在这里钉死。可信度前置同
+ * [CaptureTileManifestTest]：strings.xml 不在单测 classpath 上，缺了源码输入声明它就不会触发重跑。
+ */
+class CaptureTileStringsTest {
+
+    private val english = "src/main/res/values/strings.xml"
+    private val chinese = "src/main/res/values-zh-rCN/strings.xml"
+
+    /** The system truncates the tile label, so it has to stay short. */
+    private val maxLabelLength = 24
+
+    @Test
+    fun everyTileStringExistsInBothLocales() {
+        val names = listOf(
+            "tile_capture_label",
+            "tile_toast_overlay_required",
+            "tile_toast_unlock_first",
+        )
+        listOf(english, chinese).forEach { path ->
+            names.forEach { name ->
+                val value = stringValue(path, name)
+                assertTrue("$name must not be blank in $path", value.isNotBlank())
+            }
+        }
+    }
+
+    @Test
+    fun tileLabel_matchesTheAppNameAndStaysShort() {
+        val en = stringValue(english, "tile_capture_label")
+        val zh = stringValue(chinese, "tile_capture_label")
+
+        assertEquals("Screen Translator", en)
+        assertEquals("屏译", zh)
+        listOf(en, zh).forEach { label ->
+            assertTrue(
+                "tile label '$label' exceeds $maxLabelLength chars and would be truncated",
+                label.length <= maxLabelLength,
+            )
+        }
+    }
+
+    @Test
+    fun toasts_tableDriven_sayWhatToDoNotJustWhatFailed() {
+        data class Case(val path: String, val name: String, val mustContain: List<String>)
+
+        listOf(
+            Case(english, "tile_toast_overlay_required", listOf("Display over other apps")),
+            Case(chinese, "tile_toast_overlay_required", listOf("显示在其他应用上层")),
+            Case(english, "tile_toast_unlock_first", listOf("Unlock")),
+            Case(chinese, "tile_toast_unlock_first", listOf("解锁")),
+        ).forEach { case ->
+            val value = stringValue(case.path, case.name)
+            case.mustContain.forEach { fragment ->
+                assertTrue(
+                    "$fragment missing from ${case.name} in ${case.path}: $value",
+                    value.contains(fragment),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun neitherLocaleKeepsATodoPlaceholder() {
+        listOf(english, chinese).forEach { path ->
+            listOf("tile_capture_label", "tile_toast_overlay_required", "tile_toast_unlock_first")
+                .forEach { name ->
+                    val value = stringValue(path, name)
+                    assertFalse("$name is still a placeholder in $path: $value", value.contains("TODO", true))
+                }
+        }
+    }
+
+    private fun stringValue(resourcePath: String, resourceName: String): String {
+        val file = listOf(File(resourcePath), File("app", resourcePath))
+            .firstOrNull(File::isFile)
+            ?: error("Resource file not found: $resourcePath")
+        val document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(file)
+        val nodes = document.getElementsByTagName("string")
+        for (index in 0 until nodes.length) {
+            val node = nodes.item(index)
+            if (node.attributes?.getNamedItem("name")?.nodeValue == resourceName) {
+                return node.textContent ?: ""
+            }
+        }
+        error("$resourcePath is missing the string $resourceName")
+    }
+}

--- a/app/src/test/java/com/gameocr/app/tile/CaptureTileWiringTest.kt
+++ b/app/src/test/java/com/gameocr/app/tile/CaptureTileWiringTest.kt
@@ -1,0 +1,333 @@
+package com.gameocr.app.tile
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** 磁贴集成层的接线契约：这些接线点只有真机才能跑，所以把源码当文本读来锁住它们。 */
+class CaptureTileWiringTest {
+
+    private val service by lazy { source("src/main/java/com/gameocr/app/tile/CaptureTileService.kt") }
+    private val refresh by lazy { source("src/main/java/com/gameocr/app/tile/TileRefresh.kt") }
+    private val captureService by lazy {
+        source("src/main/java/com/gameocr/app/service/CaptureService.kt")
+    }
+
+    @Test
+    fun clickDecision_tableDriven_goesThroughThePurePolicies() {
+        data class Case(val name: String, val marker: String)
+
+        listOf(
+            Case("routing goes through the pure policy", "decideCaptureStartRoute("),
+            Case("input carries onboarding completion", "OnboardingPrefs.isCompleted("),
+            Case("input carries the overlay permission", "Settings.canDrawOverlays("),
+            Case("input carries the running service state", "CaptureServiceState.running"),
+            Case("input reuses the TileService built-in isLocked()", "isLocked = isLocked()"),
+            Case("input carries the Shizuku readiness probe", "ShizukuCapabilities.Availability.READY"),
+            Case("tile display state goes through the pure policy", "resolveCaptureTileState("),
+            Case("overload choice goes through the pure policy", "resolveTileLaunchApi("),
+            Case("BAL delegation check goes through the pure policy", "needsPendingIntentCreatorOptIn("),
+            Case("tap throttle goes through the pure policy", "shouldAcceptTileTrigger("),
+            Case("start outcome watch goes through the pure policy", "resolveTilePostClickState("),
+            Case("only start routes have an outcome to watch", "routeStartsCaptureAttempt("),
+        ).forEach { case ->
+            assertTrue("missing `${case.marker}` for: ${case.name}", normalized().contains(case.marker))
+        }
+    }
+
+    @Test
+    fun stopRoute_stopsAndIsNeverThrottled() {
+        assertShape(
+            "STOP must go through CaptureService.stopIntent",
+            "CaptureStartRoute.STOP -> startService(CaptureService.stopIntent(this))",
+        )
+        assertFalse(
+            "STOP must never be throttled",
+            normalized().contains("CaptureStartRoute.STOP -> if (acceptStart())"),
+        )
+    }
+
+    @Test
+    fun terminalState_isAppliedOnceAfterTheWholeDispatch() {
+        assertShape(
+            "the terminal state must be written after the whole route dispatch, not inside a branch: " +
+                "a per-branch write is silently skipped whenever a new route forgets to render, which " +
+                "is exactly how the tile got stuck grey after a direct start",
+            "CaptureStartRoute.UNAVAILABLE -> openMainApp() } " +
+                "resolveTileClickState(decision.route, startedDirectly)?.let(::applyTileState)",
+        )
+        val writings = normalized().split("resolveTileClickState(").size - 1
+        assertEquals("the terminal state must be decided in exactly one place", 1, writings)
+    }
+
+    @Test
+    fun clickHandler_neverRendersFromTheStaleRunningFlagAfterRouting() {
+        val block = normalized()
+            .substringAfter("override fun onClick()")
+            .substringBefore("private fun startCaptureDirect(")
+        assertFalse(
+            "onClick must not blanket-render from CaptureServiceState: on the stop path the service is " +
+                "destroyed asynchronously, so the flag still reads true and the tile would stay ACTIVE forever",
+            block.contains("renderTileState()"),
+        )
+    }
+
+    @Test
+    fun throttle_tableDriven_guardsEveryStartRouteButNothingElse() {
+        listOf(
+            "DIRECT_FGS runs the direct start and records whether it really happened" to
+                "CaptureStartRoute.DIRECT_FGS -> if (acceptStart()) " +
+                "startedDirectly = startCaptureDirect(decision.useShizuku)",
+            "TRAMPOLINE runs the projection gateway" to
+                "CaptureStartRoute.TRAMPOLINE -> if (acceptStart()) launchProjectionGateway()",
+        ).forEach { (what, shape) ->
+            assertShape("$what only after the throttle accepts it", shape)
+        }
+    }
+
+    @Test
+    fun startRoutes_useTheRealCaptureServiceActions() {
+        assertShape(
+            "the direct start must send ACTION_START",
+            "action = CaptureService.ACTION_START",
+        )
+        assertShape(
+            "the direct start must pass the Shizuku decision to the service",
+            "putExtra(CaptureService.EXTRA_USE_SHIZUKU, useShizuku)",
+        )
+        val gateway = normalized()
+            .substringAfter("private fun launchProjectionGateway()")
+            .substringBefore("private fun openOverlayPermissionSettings()")
+        assertTrue(
+            "the projection path must reuse the existing permission activity",
+            gateway.contains("startActivityFromTile(MediaProjectionRequestActivity.newIntent(this))"),
+        )
+    }
+
+    @Test
+    fun activityLaunch_branchesOnSdkAtTheCallSite() {
+        assertShape(
+            "API 34+ branch uses the PendingIntent overload",
+            "startActivityAndCollapse(pendingIntentFor(launch))",
+        )
+        assertShape(
+            "API <34 branch uses the deprecated Intent overload, suppressed for both the compiler and " +
+                "lint (`@Suppress(\"DEPRECATION\")` alone does not cover the lint id)",
+            "@Suppress(\"DEPRECATION\") @SuppressLint(\"StartActivityAndCollapseDeprecated\") " +
+                "startActivityAndCollapse(launch)",
+        )
+        assertShape(
+            "the overload choice must come from the policy, not an inline SDK_INT comparison",
+            "resolveTileLaunchApi(sdkInt) == TileLaunchApi.PENDING_INTENT",
+        )
+        assertShape(
+            "the PendingIntent creator must opt in to delegating BAL, or the launch is silently blocked",
+            "setPendingIntentCreatorBackgroundActivityStartMode( ActivityOptions.MODE_BACKGROUND_ACTIVITY_START_ALLOWED )",
+        )
+        assertShape(
+            "lint does not follow indirect checks, so the policy result must be translated for it",
+            "@ChecksSdkIntAtLeast(parameter = 0, api = TILE_PENDING_INTENT_MIN_SDK)",
+        )
+        assertShape(
+            "the BAL opt-in needs its own lint translation too, or lint's NewApi check fails the build",
+            "@ChecksSdkIntAtLeast(parameter = 0, api = PENDING_INTENT_CREATOR_OPT_IN_MIN_SDK)",
+        )
+    }
+
+    @Test
+    fun tileNeverCallsPlainStartActivity() {
+        assertFalse(
+            "launching from a tile must go through startActivityAndCollapse",
+            normalized().contains("startActivity("),
+        )
+    }
+
+    @Test
+    fun directForegroundStart_hasAFallback() {
+        val block = normalized()
+            .substringAfter("private fun startCaptureDirect(")
+            .substringBefore("private fun launchProjectionGateway(")
+        assertTrue("startCaptureDirect must guard with try/catch", block.contains("try {"))
+        assertTrue(
+            "the fallback must be the MediaProjection gateway",
+            block.contains("catch (t: Throwable)") && block.contains("launchProjectionGateway()"),
+        )
+    }
+
+    @Test
+    fun serviceNotifiesTheTileWhenItsStateChanges() {
+        assertTrue(
+            "TileRefresh must ask the system to re-bind through requestListeningState",
+            normalized(refresh).contains("requestListeningState("),
+        )
+        assertTrue(
+            "TileRefresh must target the tile component itself",
+            normalized(refresh).contains("CaptureTileService::class.java"),
+        )
+        // 按行计数必须用保留换行的 code()：normalized() 会把换行也折成空格，lineSequence() 只剩一行。
+        val notifications = code(captureService).lineSequence()
+            .count { it.contains("requestCaptureTileRefresh(this)") }
+        assertEquals(
+            "the service must notify the tile on start, on an explicit stop, and on destroy",
+            3,
+            notifications,
+        )
+    }
+
+    @Test
+    fun explicitStop_flipsTheRunningFlagBeforeDestroyingTheService() {
+        val block = normalized(captureService)
+            .substringAfter("ACTION_STOP -> {")
+            .substringBefore("ACTION_TRIGGER_ONCE")
+        assertTrue(
+            "the running flag must flip on the stop command itself: onDestroy is not guaranteed to run, " +
+                "and a tile tap leaves no second chance to render afterwards",
+            block.indexOf("setRunning(false)") in 0 until block.indexOf("stopSelf()"),
+        )
+    }
+
+    @Test
+    fun tileAdded_rendersImmediatelyInsteadOfWaitingForTheFirstTap() {
+        assertShape(
+            "adding the tile while the service runs must render at once, not leave the system default",
+            "override fun onTileAdded() { super.onTileAdded() renderTileState() }",
+        )
+    }
+
+    @Test
+    fun theWatchIsArmedAfterTheTerminalStateIsWritten() {
+        assertShape(
+            "the tile must keep looking for the start outcome after writing the optimistic state",
+            "resolveTileClickState(decision.route, startedDirectly)?.let(::applyTileState) " +
+                "if (routeStartsCaptureAttempt(decision.route)) watchStartOutcome()",
+        )
+    }
+
+    @Test
+    fun theStartOutcomeWatchIsBoundedAndReadsTheProcessStateOnly() {
+        val watch = normalized()
+            .substringAfter("private fun watchStartOutcome()")
+            .substringBefore("private fun toast(")
+        assertTrue(
+            "the watch must poll the in-process state, not ask the system",
+            watch.contains("CaptureServiceState.running.value"),
+        )
+        assertTrue(
+            "the watch must compare the stop counter against the value captured at click time, or a " +
+                "count left over from an earlier attempt would settle this one",
+            watch.contains(
+                "stoppedWithoutRunningSinceClick = " +
+                    "CaptureServiceState.stoppedWithoutRunning.value > stoppedAtClick",
+            ),
+        )
+        assertTrue(
+            "running out of attempts must not write anything — only the policy's verdict does: a wrong " +
+                "INACTIVE gets the next tap routed to STOP, killing a service that is still coming up",
+            watch.contains(
+                "if (--remaining > 0) { watchHandler.postDelayed(this, TILE_START_WATCH_INTERVAL_MS) }",
+            ),
+        )
+        assertTrue(
+            "the watch must keep polling after it writes ACTIVE: on the direct path the start looks " +
+                "successful for seconds before the dry run fails, so stopping at the first verdict " +
+                "leaves the tile parked on ACTIVE",
+            watch.contains("watchRunnable = null"),
+        )
+        assertTrue(
+            "a verdict may only be written when it changes, or a successful start would re-render the " +
+                "tile every 250ms for the whole window",
+            watch.contains(
+                "if (verdict != null && verdict != lastWritten) { applyTileState(verdict) lastWritten = verdict }",
+            ),
+        )
+    }
+
+    @Test
+    fun theStartOutcomeWatchOutlastsTheServicesSlowestSettlePath() {
+        // 直连路径会先报 running=true，之后才由 dry-run 发现起不来 —— 窗口短于服务自己的延迟就永远看不到。
+        val attempts = constant("TILE_START_WATCH_ATTEMPTS")
+        val intervalMs = constant("TILE_START_WATCH_INTERVAL_MS")
+        // 锚定 dry-run 那一段再取延迟：全文取「第一个」的话，将来在它前面新增任何一个
+        // `kotlinx.coroutines.delay(NNNL)` 都会让本断言静默比对错目标 —— 而它照样通过。
+        val dryRunAnchor = "Shizuku dry-run failed"
+        assertTrue(
+            "the dry-run failure log moved or was renamed; this check anchors on it to locate the " +
+                "service's own delayed stop, so a whole-file fallback would compare the wrong delay",
+            captureService.contains(dryRunAnchor),
+        )
+        val serviceDelayMs = Regex("""kotlinx\.coroutines\.delay\((\d+)L\)""")
+            .find(captureService.substringAfter(dryRunAnchor))
+            ?.groupValues
+            ?.get(1)
+            ?.toLong()
+            ?: error("the service's delayed stop was not found after the Shizuku dry-run failure")
+
+        assertTrue(
+            "the watch window (${attempts * intervalMs}ms) must outlast the service's delayed stop " +
+                "(${serviceDelayMs}ms), otherwise a start that fails after that delay is never seen",
+            attempts * intervalMs > serviceDelayMs,
+        )
+    }
+
+    @Test
+    fun theWatchIsCancelledWhenTheTileIsDestroyed() {
+        val destroy = normalized().substringAfter("override fun onDestroy()")
+        assertTrue(
+            "the pending poll must be removed on destroy, or it keeps ticking after the tile is gone",
+            destroy.contains("watchRunnable?.let(watchHandler::removeCallbacks)"),
+        )
+    }
+
+    private fun constant(name: String): Long = Regex("""const val $name = (\d+)""")
+        .find(code(service))
+        ?.groupValues
+        ?.get(1)
+        ?.toLong()
+        ?: error("$name not found in CaptureTileService")
+
+    @Test
+    fun serviceSignalsEveryStartFailureThatHasNoOtherExit() {
+        assertTrue(
+            "both dead ends must hand the user off to the gateway: on the direct path the missing " +
+                "projection token has no other source",
+            captureService.contains("handOffToProjectionGateway(intent)") &&
+                captureService.contains("handOffToProjectionGateway(originalIntent)"),
+        )
+        assertTrue(
+            "the hand-off decision must come from the pure policy",
+            normalized(captureService).contains("decideCaptureStartRecovery( CaptureStartRecoveryInput("),
+        )
+        val destroy = normalized(captureService).substringAfter("override fun onDestroy()")
+        assertTrue(
+            "the tile can only notice a start that ended without running through this counter: the " +
+                "refresh request is swallowed while the panel is open",
+            destroy.contains("CaptureServiceState.signalStoppedWithoutRunning()"),
+        )
+    }
+
+    /** Assert the full "route -> mechanism" shape after collapsing whitespace, not just that a token exists somewhere. */
+    private fun assertShape(message: String, shape: String) {
+        assertTrue(
+            "$message\nexpected shape: $shape",
+            normalized().contains(shape),
+        )
+    }
+
+    private fun normalized(source: String = service): String = code(source).replace(Regex("\\s+"), " ")
+
+    /**
+     * 剥掉注释、保留换行：断言读的是**代码**，不是「文件里出现过这串字」。少了这一步，把真实调用注释掉、
+     * 只在注释里提一句同名 token，断言照样通过 —— 接线的活性就没人守了。
+     */
+    private fun code(text: String): String = text
+        .replace(Regex("/\\*[\\s\\S]*?\\*/"), " ")
+        .replace(Regex("//[^\n]*"), "")
+
+    // Paths are relative to the module root; both candidates cover the repo-root and app/ working directories.
+    private fun source(path: String): String = listOf(File(path), File("app", path))
+        .firstOrNull(File::isFile)
+        ?.readText()
+        ?: error("Source not found: $path")
+}

--- a/app/src/test/java/com/gameocr/app/tile/TileClickStatePolicyTest.kt
+++ b/app/src/test/java/com/gameocr/app/tile/TileClickStatePolicyTest.kt
@@ -1,0 +1,72 @@
+package com.gameocr.app.tile
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TileClickStatePolicyTest {
+
+    @Test
+    fun clickState_tableDriven_coversEveryRoute() {
+        data class Case(
+            val route: CaptureStartRoute,
+            val directStartSucceeded: Boolean,
+            val expected: CaptureTileState?,
+        )
+
+        listOf(
+            Case(CaptureStartRoute.STOP, false, CaptureTileState.INACTIVE),
+            Case(CaptureStartRoute.DIRECT_FGS, true, CaptureTileState.ACTIVE),
+            Case(CaptureStartRoute.DIRECT_FGS, false, null),
+            Case(CaptureStartRoute.TRAMPOLINE, false, null),
+            Case(CaptureStartRoute.BLOCKED_NEED_UNLOCK, false, null),
+            Case(CaptureStartRoute.NEEDS_OVERLAY_PERMISSION, false, null),
+            Case(CaptureStartRoute.UNAVAILABLE, false, null),
+        ).forEach { case ->
+            assertEquals(
+                "route=${case.route} directStartSucceeded=${case.directStartSucceeded}",
+                case.expected,
+                resolveTileClickState(case.route, case.directStartSucceeded),
+            )
+        }
+    }
+
+    @Test
+    fun clickState_onlyWrittenWhenThePanelStaysOpen() {
+        val routesThatWrite = CaptureStartRoute.entries.filter { route ->
+            resolveTileClickState(route, directStartSucceeded = true) != null
+        }
+        assertEquals(
+            "a route may only write its own terminal state when the panel survives the click: " +
+                "stop and a direct start leave it open, so no refresh can follow; the routes that " +
+                "launch an Activity collapse it, and the service's own refresh lands normally",
+            listOf(CaptureStartRoute.STOP, CaptureStartRoute.DIRECT_FGS),
+            routesThatWrite,
+        )
+    }
+
+    @Test
+    fun stopWritesInactiveRegardlessOfTheDirectStartOutcome() {
+        listOf(false, true).forEach { succeeded ->
+            assertEquals(
+                "stopping is asynchronous, so reading the service back always yields a stale true: " +
+                    "directStartSucceeded=$succeeded",
+                CaptureTileState.INACTIVE,
+                resolveTileClickState(CaptureStartRoute.STOP, succeeded),
+            )
+        }
+    }
+
+    @Test
+    fun directStartWritesActiveOnceBecauseNoRefreshCanFollow() {
+        assertEquals(
+            CaptureTileState.ACTIVE,
+            resolveTileClickState(CaptureStartRoute.DIRECT_FGS, directStartSucceeded = true),
+        )
+        assertNull(
+            "falling back to the MediaProjection gateway collapses the panel, so the service's own " +
+                "refresh lands and a premature ACTIVE would be wrong if the user denies the capture",
+            resolveTileClickState(CaptureStartRoute.DIRECT_FGS, directStartSucceeded = false),
+        )
+    }
+}

--- a/app/src/test/java/com/gameocr/app/tile/TileLaunchPolicyTest.kt
+++ b/app/src/test/java/com/gameocr/app/tile/TileLaunchPolicyTest.kt
@@ -1,0 +1,53 @@
+package com.gameocr.app.tile
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TileLaunchPolicyTest {
+
+    @Test
+    fun launchApi_boundaryAt34() {
+        val cases = listOf(
+            24 to TileLaunchApi.LEGACY_INTENT,
+            26 to TileLaunchApi.LEGACY_INTENT,
+            29 to TileLaunchApi.LEGACY_INTENT,
+            30 to TileLaunchApi.LEGACY_INTENT,
+            31 to TileLaunchApi.LEGACY_INTENT,
+            33 to TileLaunchApi.LEGACY_INTENT,
+            34 to TileLaunchApi.PENDING_INTENT,
+            35 to TileLaunchApi.PENDING_INTENT,
+            36 to TileLaunchApi.PENDING_INTENT,
+        )
+        cases.forEach { (sdkInt, expected) ->
+            assertEquals("sdkInt=$sdkInt", expected, resolveTileLaunchApi(sdkInt))
+        }
+    }
+
+    @Test
+    fun legacyBranchIsExactlyBelow34() {
+        (0..33).forEach { sdkInt ->
+            assertEquals(
+                "sdkInt=$sdkInt must use the legacy overload",
+                TileLaunchApi.LEGACY_INTENT,
+                resolveTileLaunchApi(sdkInt),
+            )
+        }
+        (34..40).forEach { sdkInt ->
+            assertEquals(
+                "sdkInt=$sdkInt must use the PendingIntent overload",
+                TileLaunchApi.PENDING_INTENT,
+                resolveTileLaunchApi(sdkInt),
+            )
+        }
+    }
+
+    @Test
+    fun creatorOptIn_onlyFrom34() {
+        assertFalse(needsPendingIntentCreatorOptIn(33))
+        assertTrue(needsPendingIntentCreatorOptIn(34))
+        assertTrue(needsPendingIntentCreatorOptIn(35))
+        assertTrue(needsPendingIntentCreatorOptIn(36))
+    }
+}

--- a/app/src/test/java/com/gameocr/app/tile/TilePostClickStatePolicyTest.kt
+++ b/app/src/test/java/com/gameocr/app/tile/TilePostClickStatePolicyTest.kt
@@ -1,0 +1,54 @@
+package com.gameocr.app.tile
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class TilePostClickStatePolicyTest {
+
+    @Test
+    fun postClickState_tableDriven_neverDowngradesOnATimeout() {
+        data class Case(
+            val name: String,
+            val serviceRunning: Boolean,
+            val stoppedWithoutRunningSinceClick: Boolean,
+            val expected: CaptureTileState?,
+        )
+
+        listOf(
+            Case("service came up", true, false, CaptureTileState.ACTIVE),
+            Case("the start gave up", false, true, CaptureTileState.INACTIVE),
+            Case("still starting", false, false, null),
+            Case("running outranks an older instance stopping", true, true, CaptureTileState.ACTIVE),
+        ).forEach { case ->
+            assertEquals(
+                "${case.name}: running=${case.serviceRunning} stopped=${case.stoppedWithoutRunningSinceClick}",
+                case.expected,
+                resolveTilePostClickState(case.serviceRunning, case.stoppedWithoutRunningSinceClick),
+            )
+        }
+    }
+
+    @Test
+    fun anUnknownOutcomeLeavesTheOptimisticValueAlone() {
+        assertNull(
+            "writing INACTIVE here would be worse than leaving a wrong ACTIVE: the next tap would be " +
+                "routed to STOP and kill a service that is merely still coming up",
+            resolveTilePostClickState(
+                serviceRunning = false,
+                stoppedWithoutRunningSinceClick = false,
+            ),
+        )
+    }
+
+    @Test
+    fun onlyTheTwoStartRoutesHaveAnOutcomeToWaitFor() {
+        val watched = CaptureStartRoute.entries.filter(::routeStartsCaptureAttempt)
+        assertEquals(
+            "stop and the permission/availability branches never change the running state, so the tile " +
+                "has nothing to settle after them",
+            listOf(CaptureStartRoute.DIRECT_FGS, CaptureStartRoute.TRAMPOLINE),
+            watched,
+        )
+    }
+}

--- a/app/src/test/java/com/gameocr/app/tile/TileStatePolicyTest.kt
+++ b/app/src/test/java/com/gameocr/app/tile/TileStatePolicyTest.kt
@@ -1,0 +1,33 @@
+package com.gameocr.app.tile
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class TileStatePolicyTest {
+
+    @Test
+    fun state_tableDriven_matchesTheServiceAndSetupState() {
+        val cases = listOf(
+            Triple(true, true, CaptureTileState.ACTIVE),
+            Triple(true, false, CaptureTileState.INACTIVE),
+            Triple(false, true, CaptureTileState.UNAVAILABLE),
+            Triple(false, false, CaptureTileState.UNAVAILABLE),
+        )
+        cases.forEach { (setupCompleted, running, expected) ->
+            assertEquals(
+                "setupCompleted=$setupCompleted running=$running",
+                expected,
+                resolveCaptureTileState(setupCompleted, running),
+            )
+        }
+    }
+
+    @Test
+    fun shizukuReadinessMustNotMakeTileUnavailable() {
+        assertNotEquals(
+            CaptureTileState.UNAVAILABLE,
+            resolveCaptureTileState(setupCompleted = true, serviceRunning = false),
+        )
+    }
+}

--- a/app/src/test/java/com/gameocr/app/tile/TileTriggerThrottlePolicyTest.kt
+++ b/app/src/test/java/com/gameocr/app/tile/TileTriggerThrottlePolicyTest.kt
@@ -1,0 +1,44 @@
+package com.gameocr.app.tile
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TileTriggerThrottlePolicyTest {
+
+    @Test
+    fun firstTriggerIsAlwaysAccepted() {
+        assertTrue(shouldAcceptTileTrigger(lastAcceptedAtMs = null, nowMs = 0L))
+        assertTrue(shouldAcceptTileTrigger(lastAcceptedAtMs = null, nowMs = 1_700_000_000_000L))
+    }
+
+    @Test
+    fun rapidRepeatsAreSuppressed() {
+        val t0 = 1_000_000L
+        assertFalse("same millisecond", shouldAcceptTileTrigger(t0, t0))
+        assertFalse("+1ms", shouldAcceptTileTrigger(t0, t0 + 1))
+        assertFalse("+100ms", shouldAcceptTileTrigger(t0, t0 + 100))
+        assertFalse(
+            "just inside the window",
+            shouldAcceptTileTrigger(t0, t0 + TILE_TRIGGER_MIN_INTERVAL_MS - 1),
+        )
+    }
+
+    @Test
+    fun acceptedAtWindowBoundaryAndBeyond() {
+        val t0 = 1_000_000L
+        assertTrue(
+            "exactly at the window boundary",
+            shouldAcceptTileTrigger(t0, t0 + TILE_TRIGGER_MIN_INTERVAL_MS),
+        )
+        assertTrue(
+            "well past the window",
+            shouldAcceptTileTrigger(t0, t0 + TILE_TRIGGER_MIN_INTERVAL_MS * 10),
+        )
+    }
+
+    @Test
+    fun clockGoingBackwardsDoesNotLockOutForever() {
+        assertTrue(shouldAcceptTileTrigger(lastAcceptedAtMs = 2_000_000L, nowMs = 1_000_000L))
+    }
+}


### PR DESCRIPTION
## 这次做了什么

在快捷设置面板加一个磁贴，一键启动/停止截屏翻译服务 —— 不用先打开 App、再点启动按钮。对应 #23。

磁贴是纯 Android 胶水层，路由判定全部落在纯策略里（`tile/*Policy.kt`），这样上不了真机的接线也能被
源码文本契约测试锁住。已在 Xiaomi 23116PN5BC / HyperOS 与 Android 16 上真机验证。

## 文件构成（共 30 个，便于评审定位）

**按角色分**

| 角色 | 文件数 | 行数 | 说明 |
|---|---|---|---|
| **测试** | **12** | **1240（68%）** | 11 新增：`tile/` 下 10 个（6 个纯策略测试 + 4 个接线/资源契约测试）+ `CaptureStartRecoveryPolicyTest`；1 修改：`SettingsCoverageAuditTest`（守卫测试） |
| **实现** | **11** | 514 | 8 新增 `tile/`（`CaptureTileService` + 7 个纯策略）+ 1 新增 `service/CaptureStartRecoveryPolicy` + 2 修改 `CaptureService` / `CaptureServiceState` |
| 清单与资源 | 4 | 41 | `AndroidManifest.xml`、两个 `strings.xml`（均修改）+ `ic_tile_capture.xml`（新增） |
| 构建 | 1 | 19 | `app/build.gradle.kts`（**前置**，修改） |
| 设置页前置修复 | 2 | 10 | `SettingsScreen.kt` / `SettingsViewModel.kt`（**前置**，修改） |

**按新增 / 修改分**：**新增 21 个（1609 行）· 修改 9 个（+215 / -7）**
⇒ **需要逐行 diff 复核的只有那 9 个修改文件，其中 2 个合计仅 10 行。** 其余 21 个是整文件新增，按「读新文件」评审即可。

**三部分（后两者为前置，不另开 PR）**：① 磁贴 feature ② 单测输入声明 ③ 设置页前置修复。

## 关键设计决定（都是「不这么做就会坏」的那种）

**1. 运行中点击 = 停止**
选 `ACTION_STOP` 而不是「立即截一帧」：后者在「开」态下点击不翻态，与 `TOGGLEABLE_TILE=true` 的两态语义
自相矛盾；且「立即截一帧」已由悬浮球与音量键完整覆盖，而**停止入口反而是稀缺的**（悬浮球菜单与通知栏都没有停止项）。

**2. 终值必须在 `onClick` 里写死**
点击后没有第二次刷新机会：停止与直连都不收起面板，磁贴仍在监听，服务随后的 `requestListeningState` 会被系统吞掉
（已在监听时系统不再回调 `onStartListening`）。所以终值在 `TileClickStatePolicy` 里定死，并**在分发路由之后无条件写一次** ——
写进各分支的话，将来新增路由漏写一处不会有任何提示。（该机制已在真机日志中再次确认：展开面板时我们进程没有收到新的 `onStartListening`。）

**3. 启动结果用有界轮询，不用「超时即失败」**
12s 窗口盖住 Shizuku dry-run 失败后 8.5s 的延迟 `stopSelf`。不能用「等够时间就当失败」：显示未运行而服务其实在跑时，
再点会被路由成 `STOP` 把服务关掉；反过来只显示已运行而服务没起来，再点只是重试。

**4. 直连失败回落授权窗**
该路径上反馈通道全废：Toast 被 ROM 丢、服务没起来画不出悬浮错误条、面板开着时磁贴刷新又被系统吞 ——
不回落的话用户只看到「点了没反应」。

**5. SDK 分支与 lint**
`startActivityAndCollapse` 的两个重载必须按版本走（≥34 用 `PendingIntent`，<34 用已废弃的 `Intent`，否则 `NoSuchMethodError`）；
`ActivityOptions.setPendingIntentCreatorBackgroundActivityStartMode` 需 API 34。lint 不认间接判断 ⇒
两处都要 `@ChecksSdkIntAtLeast` 把策略结论翻译给它，否则 **CI 的 lint 会直接失败**（本仓库无 lint baseline，`abortOnError` 为默认 true）。

**6. `app/build.gradle.kts` 的输入声明（前置）**
把「测试实际读到的源码文件」声明为单测任务输入。这些文件不在单测 classpath 上，缺了声明它们的改动就不在依赖图上，
任务报 `UP-TO-DATE` 复用旧结果、断言形同虚设。范围跟着**测试实际读到的文件**走，而不是跟着「代码」走：
`src/main` 内还包括 `assets/*.txt` 与 drawable 图片；`src/main` 之外还有 `NOTICE`、版本目录、`llama-android` 的 cpp 源码与构建脚本
（兄弟模块不享受「改本工程构建脚本即失效」那条隐式跟踪）。代价是 `src/main` 全量参与输入指纹。

## 前置修复：设置页「最近用过的端上源语言」从不落盘

本笔同时包含一处前置修复（随本笔提交，不另开 PR）。

设置页 `buildSnapshot()` 覆盖了 `mlKitRecentSourceLanguages` 而 `save()` 没写 ⇒「最近用过的端上源语言」重排后从不落盘
（dirty 由快照重置、UI 报告已保存、持久值却没变）。新增守卫测试逐字段比对两份清单，防止再次单边漏改。

## 验证

基线：`origin/dev`（`9103245`）。以下数据全部在该基线上重跑过，**不是从旧基线搬来的**。

**Lint**（CI 的实际门槛）
- `:app:lint` **BUILD SUCCESSFUL**、**Error 0**；lint 报告中本 PR 涉及的文件 **0 条目**
- 本仓库无 `lint.xml`、无 baseline、`abortOnError` 取默认 true ⇒ **lint Error 会直接让 CI 失败**，故此项是硬门槛

**单元测试**（本机 JVM）
- 新增 11 个磁贴测试文件（5 个纯策略 + 4 个接线/资源契约 + 1 个启动恢复策略）
- 关键守卫做过**反向对照**：把 bug 放回去 ⇒ 测试立刻失败，确认它不是装饰
- 全量：`1251 tests / 4 failed`
- ⚠️ **这 4 条失败与代码逻辑无关**，全是 **Windows 检出下的 CRLF 问题**，且 CI 不跑单元测试：
  - 3 条既有：`MlKitJapaneseColumnShadowWiringTest` / `WordSelectImmediateCardTest` / `TranslationRequestAuditWiringTest`
  - 1 条 dev 自带：`SettingsScreenModelStatusTest` —— 它搜索 `"\n\n    Scaffold("`（纯 LF 模式），而 Windows 检出是 CRLF，
    于是 `indexOf` 返回 -1、`substring` 抛 `StringIndexOutOfBoundsException`。dev 的 `1aeb7a6`
    （"修正源码契约测试的换行兼容"）修过同类问题，但漏了这个测试。
  - **这 4 条涉及的文件均不在本 PR 改动范围内。**

**构建**
- 本地 `:app:assembleDebug` **BUILD SUCCESSFUL**（含 native 任务）
  —— 本机缺 Windows SDK10 lib，用 `GGML_VULKAN=OFF` 绕开，**该临时改动未提交**（`llama-android/build.gradle.kts` 保持 `ON`）

**真机**（Xiaomi 23116PN5BC / HyperOS，Android 16）
| 场景 | 结果 |
|---|---|
| 未运行 · Shizuku 就绪 · 点磁贴 | 直连 FGS、**零弹窗**、无 BAL 拦截、磁贴翻 ACTIVE |
| 运行中 · 点磁贴 | `route=STOP` → 磁贴翻 INACTIVE → 服务销毁 |
| 停止后再点 | 重新直连启动（启停循环闭合） |
| 设置未完成 · 点磁贴 | 磁贴 `UNAVAILABLE`、**不启动任何服务**、打开主屏引导 —— 不出现「假启动」 |
| 快速连点 6 次 | 路由 3+3 交替、启动 3 销毁 3、无异常、无 BAL 拦截 |
| 锁屏（熄屏前已开启）· 点磁贴 | 正常停止（`serviceRunning` 压过 `isLocked`） |
| 深色模式 / zh-rCN | 磁贴白圆+蓝箭头、标签「屏译」渲染正常 |

**原 bug「点了还是灰的」确认修复**（未附截图，用像素数据说明）：同一磁贴区域在两态下对比 ——
平均亮度 **223.1 → 185.7**；图标中心像素 **(255,255,255) → (135,135,136)**；两态差异像素占 **33.44%**。
视觉上是「白底 + 蓝色双向箭头」↔「灰底 + 白色双向箭头」。

## 怎么验证

```bash
# 单元测试（本机 JVM，不需要 native 库）
./gradlew :app:testDebugUnitTest --tests "com.gameocr.app.tile.*"

# lint —— CI 的实际门槛
./gradlew :app:lint
```

**真机手测**（需要 API 30+ 设备；磁贴在「设置 → 控制中心」里添加）
1. **Shizuku 就绪**、服务未运行 → 点磁贴：应**零弹窗**直接启动，磁贴翻亮。
2. 服务运行中 → 点磁贴：服务停止、磁贴变灰。
3. 未授权 Shizuku、模式 = MediaProjection → 点磁贴：应出现系统授权窗（不是「点了没反应」）。
4. **全新安装、从未打开过 App** → 点磁贴：磁贴应为灰色 `UNAVAILABLE`，点击打开主屏引导 ——
   **不应出现「启动了但什么都不工作」**。
5. 观察 Logcat 里不应出现 `Background activity launch blocked`。

等价的命令行驱动（FiiO 等无 `statusbar` 子命令的固件需改用人工点击）：
```bash
adb shell cmd statusbar click-tile com.gameocr.app/.tile.CaptureTileService
adb logcat -s CaptureTileService
```

## 已知限制（平台级，非本 PR 可解）

- **force-stop 后磁贴会停在旧状态**：系统不给被杀进程任何回调，只有 SystemUI 重绑磁贴才会翻正，而重绑不确定。
  平台不提供「应用自己解除 stopped」的合法后门（A15 行为变更页明文），官方先例是 force-stop 后 widget 被禁用变灰。
- **熄屏状态下点磁贴不会送达**：平台在 doze 下丢弃该输入。注意这与代码里的 `isLocked` 分支是两件事 ——
  后者管**路由决策**（锁屏时不给 MediaProjection 弹授权窗），不是「点击能否送达」。
- **Android 12 / 13 / 14 未验证**：无对应设备与镜像。`DIRECT_FGS` 已做好失败回落（`catch (t: Throwable)` → 网关 Activity）。

## 自测清单（对应 CONTRIBUTING.md）

- [x] 真机跑过 `installDebug`，主要路径可用
- [x] UI / i18n：浅色 + 深色 + 中 + 英 都过了一遍
- [x] 没有引入未使用的 import / dead code
- [x] 没有把 `.env` / `release.jks` / API Key 误提交
- [x] 新增 UI 文案写在 `values/` 与 `values-zh-rCN/` 两份
- [x] 新增 `*.kt` 包名与目录对齐（`com.gameocr.app.tile`）
